### PR TITLE
hr_payroll: fix contract views

### DIFF
--- a/hr_payroll/views/hr_contract_views.xml
+++ b/hr_payroll/views/hr_contract_views.xml
@@ -5,14 +5,12 @@
         <field name="model">hr.contract</field>
         <field name="inherit_id" ref="hr_contract.hr_contract_view_form" />
         <field name="arch" type="xml">
-            <xpath expr="//field[@name='wage']" position="after">
+            <xpath expr="//group[@name='salary_and_advantages']" position="inside">
                 <field name="struct_id" required="1" />
-            </xpath>
-            <xpath expr="//field[@name='wage']" position="before">
                 <field name="company_id" groups="base.group_multi_company" />
                 <field name="currency_id" invisible="1" />
             </xpath>
-            <xpath expr="//field[@name='resource_calendar_id']" position="after">
+            <xpath expr="//field[@name='trial_date_end']" position="after">
                 <field name="schedule_pay" />
             </xpath>
         </field>


### PR DESCRIPTION
Previously the extra fields added by this module were positioned relative to the wage and resource_calendar_id fields, however these fields are inside div tags which resulted in the new fields being irregularly placed and missing their labels

**Before:**
![image](https://user-images.githubusercontent.com/1944663/95439231-0f8ab580-09a3-11eb-938d-e57955915914.png)
![image](https://user-images.githubusercontent.com/1944663/95439248-16b1c380-09a3-11eb-9904-b4ffa037b7a0.png)

**After:**
![image](https://user-images.githubusercontent.com/1944663/95439436-5b3d5f00-09a3-11eb-8c2a-915b112dd08f.png)
![image](https://user-images.githubusercontent.com/1944663/95439300-27fad000-09a3-11eb-826b-0055fbffa97d.png)
