### PR TITLE
[13.0][IMP] payroll: replace redundant contract search method with existing functionality from hr_contract module

### DIFF
--- a/payroll/models/hr_payslip.py
+++ b/payroll/models/hr_payslip.py
@@ -298,37 +298,6 @@ class HrPayslip(models.Model):
             )
         return super(HrPayslip, self).unlink()
 
-    # TODO move this function into hr_contract module, on hr.employee object
-    @api.model
-    def get_contract(self, employee, date_from, date_to):
-        """
-        @param employee: recordset of employee
-        @param date_from: date field
-        @param date_to: date field
-        @return: returns the ids of all the contracts for the given employee
-        that need to be considered for the given dates
-        """
-        # a contract is valid if it ends between the given dates
-        clause_1 = ["&", ("date_end", "<=", date_to), ("date_end", ">=", date_from)]
-        # OR if it starts between the given dates
-        clause_2 = ["&", ("date_start", "<=", date_to), ("date_start", ">=", date_from)]
-        # OR if it starts before the date_from and finish after the date_end
-        # (or never finish)
-        clause_3 = [
-            "&",
-            ("date_start", "<=", date_from),
-            "|",
-            ("date_end", "=", False),
-            ("date_end", ">=", date_to),
-        ]
-        clause_final = (
-            [("employee_id", "=", employee.id), ("state", "=", "open"), "|", "|"]
-            + clause_1
-            + clause_2
-            + clause_3
-        )
-        return self.env["hr.contract"].search(clause_final).ids
-
     def compute_sheet(self):
         for payslip in self:
             number = payslip.number or self.env["ir.sequence"].next_by_code(
@@ -339,8 +308,11 @@ class HrPayslip(models.Model):
             # set the list of contract for which the rules have to be applied
             # if we don't give the contract, then the rules to apply should be
             # for all current contracts of the employee
-            contract_ids = payslip.contract_id.ids or self.get_contract(
-                payslip.employee_id, payslip.date_from, payslip.date_to
+            contract_ids = (
+                payslip.contract_id.ids
+                or payslip.employee_id._get_contracts(
+                    date_from=payslip.date_from, date_to=payslip.date_to
+                ).ids
             )
             lines = [
                 (0, 0, line)
@@ -585,7 +557,7 @@ class HrPayslip(models.Model):
 
         if not self.env.context.get("contract"):
             # fill with the first contract of the employee
-            contract_ids = self.get_contract(employee, date_from, date_to)
+            contract_ids = employee.contract_id.ids
         else:
             if contract_id:
                 # set the list of contract for which the input have to be filled
@@ -593,7 +565,9 @@ class HrPayslip(models.Model):
             else:
                 # if we don't give the contract, then the input to fill should
                 # be for all current contracts of the employee
-                contract_ids = self.get_contract(employee, date_from, date_to)
+                contract_ids = employee._get_contracts(
+                    date_from=date_from, date_to=date_to
+                ).ids
 
         if not contract_ids:
             return res
@@ -637,7 +611,9 @@ class HrPayslip(models.Model):
         self.company_id = employee.company_id
 
         if not self.env.context.get("contract") or not self.contract_id:
-            contract_ids = self.get_contract(employee, date_from, date_to)
+            contract_ids = employee._get_contracts(
+                date_from=date_from, date_to=date_to
+            ).ids
             if not contract_ids:
                 return
             self.contract_id = self.env["hr.contract"].browse(contract_ids[0])

--- a/payroll/tests/common.py
+++ b/payroll/tests/common.py
@@ -47,7 +47,7 @@ class TestPayslipBase(TransactionCase):
         )
 
         # I create a contract for "Richard"
-        self.env["hr.contract"].create(
+        self.richard_contract = self.env["hr.contract"].create(
             {
                 "date_end": Date.to_string(datetime.now() + timedelta(days=365)),
                 "date_start": Date.today(),
@@ -55,5 +55,6 @@ class TestPayslipBase(TransactionCase):
                 "wage": 5000.0,
                 "employee_id": self.richard_emp.id,
                 "struct_id": self.developer_pay_structure.id,
+                "state": "open",
             }
         )

--- a/payroll/tests/test_payslip_flow.py
+++ b/payroll/tests/test_payslip_flow.py
@@ -12,6 +12,17 @@ class TestPayslipFlow(TestPayslipBase):
         richard_payslip = self.env["hr.payslip"].create(
             {"name": "Payslip of Richard", "employee_id": self.richard_emp.id}
         )
+        richard_payslip.onchange_employee()
+
+        # Verify that the contract has been populated
+        self.assertEqual(
+            richard_payslip.contract_id, self.richard_contract, "Contract not set"
+        )
+
+        # Verify that worked days have been added to the payslip
+        self.assertTrue(
+            bool(richard_payslip.worked_days_line_ids), "Worked days not populated"
+        )
 
         payslip_input = self.env["hr.payslip.input"].search(
             [("payslip_id", "=", richard_payslip.id)]


### PR DESCRIPTION
A new method _get_contracts() was added in odoo v13 to the hr.employee model. This commit removes a similar method in the hr.payslip model and utilizes the core odoo method instead.