### PR TITLE
[13.0][FIX] Leave code and attendance calculation

### DIFF
--- a/payroll/models/hr_payslip.py
+++ b/payroll/models/hr_payslip.py
@@ -350,7 +350,7 @@ class HrPayslip(models.Model):
                     {
                         "name": holiday.holiday_status_id.name or _("Global Leaves"),
                         "sequence": 5,
-                        "code": holiday.holiday_status_id.name or "GLOBAL",
+                        "code": holiday.holiday_status_id.code or "GLOBAL",
                         "number_of_days": 0.0,
                         "number_of_hours": 0.0,
                         "contract_id": contract.id,
@@ -367,7 +367,10 @@ class HrPayslip(models.Model):
 
             # compute worked days
             work_data = contract.employee_id._get_work_days_data(
-                day_from, day_to, calendar=contract.resource_calendar_id
+                day_from,
+                day_to,
+                calendar=contract.resource_calendar_id,
+                compute_leaves=False,
             )
             attendances = {
                 "name": _("Normal Working Days paid at 100%"),


### PR DESCRIPTION
Hello, 

I noted that in hr_payslip.py the "code" it's refearing to the name and not the "code" in hr_holidays setted in the type field. I fixed that. 

Also in this commit, i changed the work_data to compute_leaves=False .- In some countries, the payslip should show the total amount of days (or hours) of the work schedule, and then, substract the absense days in another diferent salary_rule, so i think it's better to leave by default the calculation of the WORK100 woked day line to not consider leaves, so the user could change it in a setting (i'm developing this so i will do another pull request) or directly fetch the full work schedule days and hours and the leaves separately to work with the data in the salary rules. 

I think that is the best approach to support another countries and don't assume the user needs to discount the leaves in the worked_hours. 