### PR TITLE
[14.0][FIX] payroll_account

### DIFF
--- a/payroll_account/views/hr_payroll_account_views.xml
+++ b/payroll_account/views/hr_payroll_account_views.xml
@@ -28,6 +28,10 @@
                             groups="analytic.group_analytic_accounting"
                         />
                         <field name="account_tax_id" />
+                        <field
+                            name="tax_base_id"
+                            attrs="{'required': [('account_tax_id', '!=', False)]}"
+                        />
                     </group>
                 </page>
             </xpath>


### PR DESCRIPTION
Right now this module creates the entries correctly, but the way it has to be able to assign taxes in the lines from the salary rules is from version 12.0 and does not enter correctly, this improve is due to a vague migration that comes from version 13.0 since it was not tested at the time.