### PR TITLE
[14.0] [IMP] Add details in salary rule calculation exeptions

### DIFF
--- a/payroll/models/hr_salary_rule.py
+++ b/payroll/models/hr_salary_rule.py
@@ -202,10 +202,17 @@ class HrSalaryRule(models.Model):
                     "result_qty" in localdict and localdict["result_qty"] or 1.0,
                     "result_rate" in localdict and localdict["result_rate"] or 100.0,
                 )
-            except Exception:
+            except Exception as ex:
                 raise UserError(
-                    _("Wrong python code defined for salary rule %s (%s).")
-                    % (self.name, self.code)
+                    _(
+                        """
+Wrong python code defined for salary rule %s (%s).
+Here is the error received:
+
+%s
+"""
+                    )
+                    % (self.name, self.code, repr(ex))
                 )
 
     def _satisfy_condition(self, localdict):
@@ -234,8 +241,15 @@ class HrSalaryRule(models.Model):
             try:
                 safe_eval(self.condition_python, localdict, mode="exec", nocopy=True)
                 return "result" in localdict and localdict["result"] or False
-            except Exception:
+            except Exception as ex:
                 raise UserError(
-                    _("Wrong python condition defined for salary rule %s (%s).")
-                    % (self.name, self.code)
+                    _(
+                        """
+Wrong python condition defined for salary rule %s (%s).
+Here is the error received:
+
+%s
+"""
+                    )
+                    % (self.name, self.code, repr(ex))
                 )


### PR DESCRIPTION
This improvement adds the error message returned from safe_eval method in python conditions and salary rules calculation. 
I think this is a simple and important improvement to the module because it helps the user to debug his own custom salary rules. 

In the way it works now, the exception it's catched and it only shows the message "There is an error in salary rule calculation", and there is not explanation of the error. So the user, might not be able to debug their salary rule, and it's forced to edit the module code to allow the error to show up (that's what i had to do in development environment to be able to debug custom complex salary rules). 

So i think it's very useful to show the error trace to the user so it can debug the method without problem. Most of the salary rules error can be easily fixed looking at the error that the method safe_eval throws when it fails. 

pre-commit and checks runs okay in my end. I hope it's ready for merge. 