### PR TITLE
[14.0] [IMP] Code fields for python compute fields

### DIFF
--- a/payroll/views/hr_salary_rule_views.xml
+++ b/payroll/views/hr_salary_rule_views.xml
@@ -99,6 +99,9 @@
                                 name="condition_python"
                                 attrs="{'invisible':[('condition_select','!=','python')], 'required': [('condition_select','=','python')]}"
                                 colspan="4"
+                                widget="ace"
+                                options="{'mode': 'python'}"
+                                id="condition_python"
                             />
                             <newline />
                             <field
@@ -140,6 +143,9 @@
                                 colspan="4"
                                 name="amount_python_compute"
                                 attrs="{'invisible':[('amount_select','!=','code')], 'required':[('amount_select','=','code')]}"
+                                widget="ace"
+                                options="{'mode': 'python'}"
+                                id="amount_python_compute"
                             />
                             <field
                                 name="amount_percentage"


### PR DESCRIPTION
Hello, 

In this improvement, the form fields for "code" input in salary rules conditions and calculations, are now displayed like code. This makes easy to create the conditions and helps with indentation and readability. 

Here i attach image of the new look: 
<img width="1653" alt="Screen Shot 2022-02-15 at 00 03 08" src="https://user-images.githubusercontent.com/12401188/153984917-6b285db4-76a3-4fe5-99d5-06bd23aa828d.png">

Hope you like it and this get merged. I will submit new little changes and updates for the module because i use it extensively in my business. Hope it helps. 

Regards. 
