### PR TITLE
14.0-minor-changes-and-tweaks

### DIFF
--- a/payroll/models/hr_payslip.py
+++ b/payroll/models/hr_payslip.py
@@ -340,6 +340,10 @@ class HrPayslip(models.Model):
         ):
             day_from = datetime.combine(date_from, time.min)
             day_to = datetime.combine(date_to, time.max)
+            day_contract_start = datetime.combine(contract.date_start, time.min)
+            # only use payslip live from if it's greather than contract start date
+            if day_from < day_contract_start:
+                day_from = day_contract_start
 
             # compute leave days
             leaves = {}
@@ -597,7 +601,7 @@ class HrPayslip(models.Model):
         )
         return res
 
-    @api.onchange("employee_id", "date_from", "date_to")
+    @api.onchange("employee_id", "date_from", "date_to", "struct_id")
     def onchange_employee(self):
 
         if (not self.employee_id) or (not self.date_from) or (not self.date_to):
@@ -628,7 +632,9 @@ class HrPayslip(models.Model):
 
         if not self.contract_id.struct_id:
             return
-        self.struct_id = self.contract_id.struct_id
+
+        if not self.struct_id:
+            self.struct_id = self.contract_id.struct_id
 
         # computation of the salary input
         contracts = self.env["hr.contract"].browse(contract_ids)

--- a/payroll/models/hr_payslip_input.py
+++ b/payroll/models/hr_payslip_input.py
@@ -16,6 +16,9 @@ class HrPayslipInput(models.Model):
     code = fields.Char(
         required=True, help="The code that can be used in the salary rules"
     )
+    amount_qty = fields.Float(
+        "Amount Quantity", help="It can be used in computation for other inputs"
+    )
     amount = fields.Float(
         help="It is used in computation. For e.g. A rule for sales having "
         "1% commission of basic salary for per product can defined in "

--- a/payroll/views/hr_payslip_views.xml
+++ b/payroll/views/hr_payslip_views.xml
@@ -114,7 +114,7 @@
                     <field
                         name="state"
                         widget="statusbar"
-                        statusbar_visible="draft,confirm"
+                        statusbar_visible="draft,verify,done,cancel"
                     />
                 </header>
                 <sheet>
@@ -122,6 +122,7 @@
                         <button
                             name="%(hr_payslip_line_action_computation_details)d"
                             class="oe_stat_button"
+                            style="width: 220px"
                             icon="fa-money"
                             type="action"
                         >
@@ -212,15 +213,20 @@
                                     editable="bottom"
                                     decoration-info="total == 0"
                                 >
-                                    <field name="name" />
                                     <field name="code" />
+                                    <field name="name" />
                                     <field name="category_id" />
                                     <field name="sequence" invisible="1" />
                                     <field name="quantity" />
                                     <field name="rate" />
-                                    <field name="salary_rule_id" />
+                                    <field name="salary_rule_id" invisible="1" />
                                     <field name="amount" />
-                                    <field name="total" />
+                                    <field
+                                        name="total"
+                                        decoration-bf="1"
+                                        decoration-danger="0 > total"
+                                        decoration-success="total > 0"
+                                    />
                                 </tree>
                                 <form string="Payslip Line">
                                     <group col="4">
@@ -247,10 +253,15 @@
                                     string="Payslip Lines"
                                     decoration-info="total == 0"
                                 >
-                                    <field name="category_id" />
+                                    <field name="category_id" decoration-bf="1" />
+                                    <field name="code" widget="badge" />
                                     <field name="name" />
-                                    <field name="code" />
-                                    <field name="total" />
+                                    <field
+                                        name="total"
+                                        decoration-bf="1"
+                                        decoration-danger="0 > total"
+                                        decoration-success="total > 0"
+                                    />
                                 </tree>
                             </field>
                         </page>

--- a/payroll/views/hr_salary_rule_views.xml
+++ b/payroll/views/hr_salary_rule_views.xml
@@ -91,74 +91,79 @@
                 </group>
                 <notebook colspan="6">
                     <page string="General">
-                        <group col="4">
-                            <separator colspan="4" string="Conditions" />
-                            <field name="condition_select" />
-                            <newline />
-                            <field
-                                name="condition_python"
-                                attrs="{'invisible':[('condition_select','!=','python')], 'required': [('condition_select','=','python')]}"
-                                colspan="4"
-                                widget="ace"
-                                options="{'mode': 'python'}"
-                                id="condition_python"
-                            />
-                            <newline />
-                            <field
-                                name="condition_range"
-                                attrs="{'invisible':[('condition_select','!=','range')], 'required':[('condition_select','=','range')]}"
-                            />
-                            <newline />
-                            <field
-                                name="condition_range_min"
-                                colspan="2"
-                                attrs="{'invisible':[('condition_select','!=','range')], 'required':[('condition_select','=','range')]}"
-                            />
-                            <newline />
-                            <field
-                                name="condition_range_max"
-                                colspan="2"
-                                attrs="{'invisible':[('condition_select','!=','range')], 'required':[('condition_select','=','range')]}"
-                            />
-                            <newline />
-                            <separator colspan="4" string="Computation" />
-                            <field name="amount_select" />
-                            <newline />
-                            <field
-                                name="amount_percentage_base"
-                                attrs="{'invisible':[('amount_select','!=','percentage')], 'required': [('amount_select','=','percentage')]}"
-                            />
-                            <newline />
-                            <field
-                                name="quantity"
-                                attrs="{'invisible':[('amount_select','=','code')], 'required':[('amount_select','!=','code')]}"
-                            />
-                            <newline />
-                            <field
-                                name="amount_fix"
-                                attrs="{'invisible':[('amount_select','!=','fix')], 'required':[('amount_select','=','fix')]}"
-                            />
-                            <newline />
-                            <field
-                                colspan="4"
-                                name="amount_python_compute"
-                                attrs="{'invisible':[('amount_select','!=','code')], 'required':[('amount_select','=','code')]}"
-                                widget="ace"
-                                options="{'mode': 'python'}"
-                                id="amount_python_compute"
-                            />
-                            <field
-                                name="amount_percentage"
-                                attrs="{'invisible':[('amount_select','!=','percentage')], 'required':[('amount_select','=','percentage')]}"
-                            />
-                            <separator colspan="4" string="Company Contribution" />
-                            <field name="register_id" />
+                        <group>
+                            <group col="4">
+                                <separator colspan="4" string="Conditions" />
+                                <field name="condition_select" />
+                                <newline />
+                                <field
+                                    name="condition_python"
+                                    attrs="{'invisible':[('condition_select','!=','python')], 'required': [('condition_select','=','python')]}"
+                                    colspan="4"
+                                    widget="ace"
+                                    options="{'mode': 'python'}"
+                                    id="condition_python"
+                                />
+                                <newline />
+                                <field
+                                    name="condition_range"
+                                    attrs="{'invisible':[('condition_select','!=','range')], 'required':[('condition_select','=','range')]}"
+                                />
+                                <newline />
+                                <field
+                                    name="condition_range_min"
+                                    colspan="2"
+                                    attrs="{'invisible':[('condition_select','!=','range')], 'required':[('condition_select','=','range')]}"
+                                />
+                                <newline />
+                                <field
+                                    name="condition_range_max"
+                                    colspan="2"
+                                    attrs="{'invisible':[('condition_select','!=','range')], 'required':[('condition_select','=','range')]}"
+                                />
+                                <newline />
+                                <separator colspan="4" string="Computation" />
+                                <field name="amount_select" />
+                                <newline />
+                                <field
+                                    name="amount_percentage_base"
+                                    attrs="{'invisible':[('amount_select','!=','percentage')], 'required': [('amount_select','=','percentage')]}"
+                                />
+                                <newline />
+                                <field
+                                    name="quantity"
+                                    attrs="{'invisible':[('amount_select','=','code')], 'required':[('amount_select','!=','code')]}"
+                                />
+                                <newline />
+                                <field
+                                    name="amount_fix"
+                                    attrs="{'invisible':[('amount_select','!=','fix')], 'required':[('amount_select','=','fix')]}"
+                                />
+                                <newline />
+                                <field
+                                    colspan="4"
+                                    name="amount_python_compute"
+                                    attrs="{'invisible':[('amount_select','!=','code')], 'required':[('amount_select','=','code')]}"
+                                    widget="ace"
+                                    options="{'mode': 'python'}"
+                                    id="amount_python_compute"
+                                />
+                                <field
+                                    name="amount_percentage"
+                                    attrs="{'invisible':[('amount_select','!=','percentage')], 'required':[('amount_select','=','percentage')]}"
+                                />
+                            </group>
+                            <group>
+                                <separator string="Company Contribution" />
+                                <field name="register_id" />
+                            </group>
                         </group>
-                    </page>
-                    <page name="rules" string="Child Rules">
-                        <field name="parent_rule_id" />
-                        <separator string="Children Definition" />
-                        <field name="child_ids" />
+                        <separator colspan="4" string="Description" />
+                        <field
+                            name="note"
+                            nolabel="1"
+                            placeholder="Write a description for this rule..."
+                        />
                     </page>
                     <page string="Inputs">
                         <field name="input_ids" mode="tree">
@@ -168,8 +173,10 @@
                             </tree>
                         </field>
                     </page>
-                    <page string="Description">
-                        <field name="note" />
+                    <page name="rules" string="Child Rules">
+                        <field name="parent_rule_id" />
+                        <separator string="Children Definition" />
+                        <field name="child_ids" />
                     </page>
                 </notebook>
             </form>


### PR DESCRIPTION
Hello, this PR adds more tweaks and fixes to the module. Like you know, i'm working intensively in this module for the Argentinian Localization for Payroll. 

Features and changes in this PR: 
- It adds a feature that takes into account the employee contract "start_date" for the calculations in the payslips. For example: If the employee started working before the "from_date" of payslip, payslip will only calculate work days and other data taking "start_date" as employee "from_date" for this payslip. This allows to don't have to make changes if the employee starts working in middle of a period/month. 
- Adds "struct_id" into onchange_employee method and support re-calculating all payslip worked_days and inputs when you change the "struct_id". This is useful if you have inputs and worked_days that calculates automatically depending of the rules included in the payslip. So we only calculate these lines when we need them. 
- Adds amount_qty to payslip inputs table. This give us an extra field which could be useful if we use inputs to fetch values which can have more than 1 unit. This do not modify any functionality and the amount_qty field added could be ignored completely if not used. 
- Add other states to payslip statusbar. 
- Reordered the hr_salary_rule view to have a more concise and practical view to create rules. 
- Minor view UX and UI improvements

If you like the PR please support it to get merged. Like you know, i will be making more PRs like this improving the module. 

Any suggestion is welcomed. 