### PR TITLE
[14.0] [IMP] Payslip logic and view improvements

### DIFF
--- a/payroll/models/hr_payslip.py
+++ b/payroll/models/hr_payslip.py
@@ -601,7 +601,7 @@ class HrPayslip(models.Model):
         )
         return res
 
-    @api.onchange("employee_id", "date_from", "date_to")
+    @api.onchange("employee_id", "date_from", "date_to", "struct_id")
     def onchange_employee(self):
 
         if (not self.employee_id) or (not self.date_from) or (not self.date_to):
@@ -632,7 +632,9 @@ class HrPayslip(models.Model):
 
         if not self.contract_id.struct_id:
             return
-        self.struct_id = self.contract_id.struct_id
+
+        if not self.struct_id:
+            self.struct_id = self.contract_id.struct_id
 
         # computation of the salary input
         contracts = self.env["hr.contract"].browse(contract_ids)

--- a/payroll/models/hr_payslip.py
+++ b/payroll/models/hr_payslip.py
@@ -340,6 +340,10 @@ class HrPayslip(models.Model):
         ):
             day_from = datetime.combine(date_from, time.min)
             day_to = datetime.combine(date_to, time.max)
+            day_contract_start = datetime.combine(contract.date_start, time.min)
+            # only use payslip day_from if it's greather than contract start date
+            if day_from < day_contract_start:
+                day_from = day_contract_start
 
             # compute leave days
             leaves = {}

--- a/payroll/models/hr_payslip_input.py
+++ b/payroll/models/hr_payslip_input.py
@@ -21,6 +21,9 @@ class HrPayslipInput(models.Model):
         "1% commission of basic salary for per product can defined in "
         "expression like result = inputs.SALEURO.amount * contract.wage*0.01."
     )
+    amount_qty = fields.Float(
+        "Amount Quantity", help="It can be used in computation for other inputs"
+    )
     contract_id = fields.Many2one(
         "hr.contract",
         string="Contract",

--- a/payroll/views/hr_payslip_views.xml
+++ b/payroll/views/hr_payslip_views.xml
@@ -114,7 +114,7 @@
                     <field
                         name="state"
                         widget="statusbar"
-                        statusbar_visible="draft,confirm"
+                        statusbar_visible="draft,verify,done,cancel"
                     />
                 </header>
                 <sheet>

--- a/payroll/views/hr_payslip_views.xml
+++ b/payroll/views/hr_payslip_views.xml
@@ -190,6 +190,7 @@
                                 <tree string="Input Data" editable="bottom">
                                     <field name="name" />
                                     <field name="code" />
+                                    <field name="amount_qty" />
                                     <field name="amount" />
                                     <field name="contract_id" />
                                     <field name="sequence" invisible="True" />

--- a/payroll/views/hr_salary_rule_views.xml
+++ b/payroll/views/hr_salary_rule_views.xml
@@ -6,8 +6,8 @@
         <field name="arch" type="xml">
             <tree string="Salary Rules">
                 <field name="name" />
-                <field name="code" />
-                <field name="category_id" />
+                <field name="code" decoration-bf="1" />
+                <field name="category_id" widget="badge" />
                 <field name="sequence" invisible="1" />
                 <field name="register_id" />
             </tree>
@@ -29,7 +29,7 @@
                                 </div>
                                 <div class="col-4">
                                     <span class="float-right">
-                                        <field name="category_id" />
+                                        <field name="category_id" widget="badge" />
                                     </span>
                                 </div>
                             </div>
@@ -78,81 +78,94 @@
                 <h2>
                     <field name="category_id" />
                 </h2>
-                <group col="4">
-                    <field name="code" />
-                    <field name="sequence" />
-                    <field name="active" />
-                    <field name="appears_on_payslip" />
-                    <field
-                        name="company_id"
-                        options="{'no_create': True}"
-                        groups="base.group_multi_company"
-                    />
+                <group name="principal">
+                    <group>
+                        <field name="code" />
+                        <field name="sequence" />
+                        <field
+                            name="company_id"
+                            options="{'no_create': True}"
+                            groups="base.group_multi_company"
+                        />
+                    </group>
+                    <group>
+                        <field name="active" />
+                        <field name="appears_on_payslip" />
+                    </group>
                 </group>
-                <notebook colspan="6">
+                <notebook>
                     <page string="General">
-                        <group col="4">
-                            <separator colspan="4" string="Conditions" />
-                            <field name="condition_select" />
-                            <newline />
+                        <group>
+                            <group string="Conditions" name="conditions">
+                                <field name="condition_select" />
+                                <field
+                                    name="condition_python"
+                                    attrs="{'invisible':[('condition_select','!=','python')], 'required': [('condition_select','=','python')]}"
+                                    colspan="4"
+                                    widget="ace"
+                                    options="{'mode': 'python'}"
+                                    id="condition_python"
+                                />
+                                <field
+                                    name="condition_range"
+                                    attrs="{'invisible':[('condition_select','!=','range')], 'required':[('condition_select','=','range')]}"
+                                />
+                                <label
+                                    string="Condition Range"
+                                    attrs="{'invisible':[('condition_select','!=','range')], 'required':[('condition_select','=','range')]}"
+                                    for="condition_range_min"
+                                />
+                                <div
+                                    attrs="{'invisible':[('condition_select','!=','range')], 'required':[('condition_select','=','range')]}"
+                                >
+                                    <strong>Between </strong>
+                                    <field
+                                        name="condition_range_min"
+                                        class="oe_inline"
+                                        attrs="{'invisible':[('condition_select','!=','range')], 'required':[('condition_select','=','range')]}"
+                                    />
+                                    <strong> and </strong>
+                                    <field
+                                        name="condition_range_max"
+                                        class="oe_inline"
+                                        attrs="{'invisible':[('condition_select','!=','range')], 'required':[('condition_select','=','range')]}"
+                                    />
+                                </div>
+                                <separator colspan="4" string="Company Contribution" />
+                                <field name="register_id" />
+                            </group>
+                            <group string="Computation" name="computation">
+                                <field name="amount_select" />
+                                <field
+                                    name="amount_percentage_base"
+                                    attrs="{'invisible':[('amount_select','!=','percentage')], 'required': [('amount_select','=','percentage')]}"
+                                />
+                                <field
+                                    name="quantity"
+                                    attrs="{'invisible':[('amount_select','=','code')], 'required':[('amount_select','!=','code')]}"
+                                />
+                                <field
+                                    name="amount_fix"
+                                    attrs="{'invisible':[('amount_select','!=','fix')], 'required':[('amount_select','=','fix')]}"
+                                />
+                                <field
+                                    colspan="4"
+                                    name="amount_python_compute"
+                                    attrs="{'invisible':[('amount_select','!=','code')], 'required':[('amount_select','=','code')]}"
+                                    widget="ace"
+                                    options="{'mode': 'python'}"
+                                    id="amount_python_compute"
+                                />
+                                <field
+                                    name="amount_percentage"
+                                    attrs="{'invisible':[('amount_select','!=','percentage')], 'required':[('amount_select','=','percentage')]}"
+                                />
+                            </group>
+                            <separator string="Notes" />
                             <field
-                                name="condition_python"
-                                attrs="{'invisible':[('condition_select','!=','python')], 'required': [('condition_select','=','python')]}"
-                                colspan="4"
-                                widget="ace"
-                                options="{'mode': 'python'}"
-                                id="condition_python"
+                                name="note"
+                                placeholder="Write salary rule notes or observations here..."
                             />
-                            <newline />
-                            <field
-                                name="condition_range"
-                                attrs="{'invisible':[('condition_select','!=','range')], 'required':[('condition_select','=','range')]}"
-                            />
-                            <newline />
-                            <field
-                                name="condition_range_min"
-                                colspan="2"
-                                attrs="{'invisible':[('condition_select','!=','range')], 'required':[('condition_select','=','range')]}"
-                            />
-                            <newline />
-                            <field
-                                name="condition_range_max"
-                                colspan="2"
-                                attrs="{'invisible':[('condition_select','!=','range')], 'required':[('condition_select','=','range')]}"
-                            />
-                            <newline />
-                            <separator colspan="4" string="Computation" />
-                            <field name="amount_select" />
-                            <newline />
-                            <field
-                                name="amount_percentage_base"
-                                attrs="{'invisible':[('amount_select','!=','percentage')], 'required': [('amount_select','=','percentage')]}"
-                            />
-                            <newline />
-                            <field
-                                name="quantity"
-                                attrs="{'invisible':[('amount_select','=','code')], 'required':[('amount_select','!=','code')]}"
-                            />
-                            <newline />
-                            <field
-                                name="amount_fix"
-                                attrs="{'invisible':[('amount_select','!=','fix')], 'required':[('amount_select','=','fix')]}"
-                            />
-                            <newline />
-                            <field
-                                colspan="4"
-                                name="amount_python_compute"
-                                attrs="{'invisible':[('amount_select','!=','code')], 'required':[('amount_select','=','code')]}"
-                                widget="ace"
-                                options="{'mode': 'python'}"
-                                id="amount_python_compute"
-                            />
-                            <field
-                                name="amount_percentage"
-                                attrs="{'invisible':[('amount_select','!=','percentage')], 'required':[('amount_select','=','percentage')]}"
-                            />
-                            <separator colspan="4" string="Company Contribution" />
-                            <field name="register_id" />
                         </group>
                     </page>
                     <page name="rules" string="Child Rules">
@@ -163,13 +176,10 @@
                     <page string="Inputs">
                         <field name="input_ids" mode="tree">
                             <tree string="Input Data" editable="bottom">
-                                <field name="name" />
                                 <field name="code" />
+                                <field name="name" />
                             </tree>
                         </field>
-                    </page>
-                    <page string="Description">
-                        <field name="note" />
                     </page>
                 </notebook>
             </form>


### PR DESCRIPTION
**- New PR replacing #33** 

Features and changes in this PR:

- It adds a feature that takes into account the employee contract "start_date" for the calculations in the payslips. For example: If the employee started working after the "from_date" of payslip, payslip will only calculate work days and other data taking "start_date" as employee "from_date" for this payslip. This allows to don't have to make changes if the employee starts working in middle of a period/month.
- Adds "struct_id" into onchange_employee method and support re-calculating all payslip worked_days and inputs when you change the "struct_id". This is useful if you have inputs and worked_days that calculates automatically depending of the rules included in the payslip. So we only calculate these lines when we need them.
- Adds amount_qty to payslip inputs table. This give us an extra field which could be useful if we use inputs to fetch values which can have more than 1 unit. This do not modify any functionality and the amount_qty field added could be ignored completely if not used.
- Add other states to payslip statusbar.
- Reordered the hr_salary_rule view to have a more concise and practical view to create rules.
- Minor view UX and UI improvements

If you like the PR please support it to get merged. Like you know, i will be making more PRs like this improving the module.

Any suggestion is welcomed.