### PR TITLE
[IMP] payroll: add support for hr_public_holidays in payroll

### DIFF
--- a/payroll/models/hr_payslip.py
+++ b/payroll/models/hr_payslip.py
@@ -339,18 +339,15 @@ class HrPayslip(models.Model):
         for contract in contracts.filtered(
             lambda contract: contract.resource_calendar_id
         ):
-
             # Adds support for the hr_public_holidays module.
             # This adds support to exclude public holidays from work days computation.
             # If you don't use the module, it don't make any difference or harm.
             contract = contract.with_context(
                 employee_id=self.employee_id.id, exclude_public_holidays=True
             )
-
             day_from = datetime.combine(date_from, time.min)
             day_to = datetime.combine(date_to, time.max)
             day_contract_start = datetime.combine(contract.date_start, time.min)
-
             # only use payslip day_from if it's greather than contract start date
             if day_from < day_contract_start:
                 day_from = day_contract_start

--- a/payroll/models/hr_payslip.py
+++ b/payroll/models/hr_payslip.py
@@ -339,9 +339,18 @@ class HrPayslip(models.Model):
         for contract in contracts.filtered(
             lambda contract: contract.resource_calendar_id
         ):
+
+            # Adds support for the hr_public_holidays module.
+            # This adds support to exclude public holidays from work days computation.
+            # If you don't use the module, it don't make any difference or harm.
+            contract = contract.with_context(
+                employee_id=self.employee_id.id, exclude_public_holidays=True
+            )
+
             day_from = datetime.combine(date_from, time.min)
             day_to = datetime.combine(date_to, time.max)
             day_contract_start = datetime.combine(contract.date_start, time.min)
+
             # only use payslip day_from if it's greather than contract start date
             if day_from < day_contract_start:
                 day_from = day_contract_start


### PR DESCRIPTION
Hello, here a small PR. 

This add support to exclude the public holidays defined if you are using the OCA module hr_public_holidays. Before this change, payroll worked days calculations were no taking into account the public_holidays. 

Passing a context to the worked days method makes public holidays to be excluded in the calculations. If you are no using the module, it makes no difference or harm to pass this context. 

So this adds fully support for the module without making difference to the people who don't use it. 

@appstogrow @pedrobaeza What do u think? 