### PR TITLE
[14.0][FIX] payroll unittest

### DIFF
--- a/payroll/tests/common.py
+++ b/payroll/tests/common.py
@@ -10,6 +10,8 @@ class TestPayslipBase(TransactionCase):
     def setUp(self):
         super(TestPayslipBase, self).setUp()
 
+        self.Payslip = self.env["hr.payslip"]
+
         # Some salary rules references
         self.hra_rule_id = self.ref("payroll.hr_salary_rule_houserentallowance1")
         self.conv_rule_id = self.ref("payroll.hr_salary_rule_convanceallowance1")
@@ -17,6 +19,9 @@ class TestPayslipBase(TransactionCase):
         self.pf_rule_id = self.ref("payroll.hr_salary_rule_providentfund1")
         self.mv_rule_id = self.ref("payroll.hr_salary_rule_meal_voucher")
         self.comm_rule_id = self.ref("payroll.hr_salary_rule_sales_commission")
+        self.basic_rule_id = self.ref("payroll.hr_rule_basic")
+        self.gross_rule_id = self.ref("payroll.hr_rule_taxable")
+        self.net_rule_id = self.ref("payroll.hr_rule_net")
 
         # I create a new employee "Richard"
         self.richard_emp = self.env["hr.employee"].create(
@@ -42,6 +47,9 @@ class TestPayslipBase(TransactionCase):
                     (4, self.pf_rule_id),
                     (4, self.mv_rule_id),
                     (4, self.comm_rule_id),
+                    (4, self.basic_rule_id),
+                    (4, self.gross_rule_id),
+                    (4, self.net_rule_id),
                 ],
             }
         )
@@ -55,5 +63,11 @@ class TestPayslipBase(TransactionCase):
                 "wage": 5000.0,
                 "employee_id": self.richard_emp.id,
                 "struct_id": self.developer_pay_structure.id,
+                "kanban_state": "done",
             }
         )
+
+    def apply_contract_cron(self):
+        self.env.ref(
+            "hr_contract.ir_cron_data_contract_update_state"
+        ).method_direct_trigger()

--- a/payroll/tests/test_payslip_flow.py
+++ b/payroll/tests/test_payslip_flow.py
@@ -40,7 +40,7 @@ class TestPayslipFlow(TestPayslipBase):
         richard_payslip.with_context(context).compute_sheet()
 
         # Find the 'NET' payslip line and check that it adds up
-        # salary + HRA + CA + MA + SALE - PF - PT
+        # salary + HRA + MA + SALE - PT
         work100 = richard_payslip.worked_days_line_ids.filtered(
             lambda x: x.code == "WORK100"
         )
@@ -48,13 +48,7 @@ class TestPayslipFlow(TestPayslipBase):
         self.assertEqual(len(line), 1, "I found the 'NET' line")
         self.assertEqual(
             line[0].amount,
-            5000.0
-            + (0.4 * 5000)
-            + 800.0
-            + (work100.number_of_days * 10)
-            + 0.05
-            - 200.0
-            - (0.125 * 5000),
+            5000.0 + (0.4 * 5000) + (work100.number_of_days * 10) + 0.05 - 200.0,
             "The 'NET' amount equals salary plus allowances - deductions",
         )
 


### PR DESCRIPTION
The unittest for the payroll module is broken in several ways:

1. It doesn't actually test anything in the payslip, just the states when various buttons are simulated
2. The payslip is created programatically, so no payslip values are loaded
3. The employee's contract is in "draft" state so even if it tried to load any values it wouldn't work because the contract isn't "open"
4. It modifies a salary input line, but doesn't verify it worked. It won't work because of the above mentioned reasons.


To ensure a minimal amount of testing:

- Make sure the employee's contract is in "open" state
- Use the "Form" testing object when creating a payslip to ensure the onchange_employee() method is run
- Actually test the payroll calculations are done correctly