### PR TITLE
[14.0][FIX] payroll - wrong quantity and rate during python computation of salary rule

### DIFF
--- a/payroll/models/hr_salary_rule.py
+++ b/payroll/models/hr_salary_rule.py
@@ -197,10 +197,16 @@ class HrSalaryRule(models.Model):
                 safe_eval(
                     self.amount_python_compute, localdict, mode="exec", nocopy=True
                 )
+                result_qty = 1.0
+                result_rate = 100.0
+                if "result_qty" in localdict:
+                    result_qty = localdict["result_qty"]
+                if "result_rate" in localdict:
+                    result_rate = localdict["result_rate"]
                 return (
                     float(localdict["result"]),
-                    "result_qty" in localdict and localdict["result_qty"] or 1.0,
-                    "result_rate" in localdict and localdict["result_rate"] or 100.0,
+                    float(result_qty),
+                    float(result_rate),
                 )
             except Exception as ex:
                 raise UserError(

--- a/payroll/tests/__init__.py
+++ b/payroll/tests/__init__.py
@@ -1,3 +1,4 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from . import test_hr_salary_rule
 from . import test_payslip_flow

--- a/payroll/tests/test_hr_salary_rule.py
+++ b/payroll/tests/test_hr_salary_rule.py
@@ -45,3 +45,25 @@ class TestSalaryRule(TestPayslipBase):
         self.assertEqual(line.amount, 0.0, "The amount is zero")
         self.assertEqual(line.rate, 0.0, "The rate is zero")
         self.assertEqual(line.quantity, 0.0, "The quantity is zero")
+
+    def test_python_code_result_not_set(self):
+
+        self.test_rule.amount_python_compute = "result = 2"
+
+        # Open contracts
+        cc = self.env["hr.contract"].search([("employee_id", "=", self.richard_emp.id)])
+        cc.kanban_state = "done"
+        self.env.ref(
+            "hr_contract.ir_cron_data_contract_update_state"
+        ).method_direct_trigger()
+
+        # Create payslip and compute
+        payslip = self.Payslip.create({"employee_id": self.richard_emp.id})
+        payslip.onchange_employee()
+        payslip.compute_sheet()
+
+        line = payslip.line_ids.filtered(lambda l: l.code == "TEST")
+        self.assertEqual(len(line), 1, "I found the Test line")
+        self.assertEqual(line.amount, 2.0, "The amount is zero")
+        self.assertEqual(line.rate, 100.0, "The rate is zero")
+        self.assertEqual(line.quantity, 1.0, "The quantity is zero")

--- a/payroll/tests/test_hr_salary_rule.py
+++ b/payroll/tests/test_hr_salary_rule.py
@@ -1,0 +1,47 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from .common import TestPayslipBase
+
+
+class TestSalaryRule(TestPayslipBase):
+    def setUp(self):
+        super().setUp()
+
+        self.Payslip = self.env["hr.payslip"]
+        self.Rule = self.env["hr.salary.rule"]
+
+        self.test_rule = self.Rule.create(
+            {
+                "name": "test rule",
+                "code": "TEST",
+                "category_id": self.env.ref("payroll.ALW").id,
+                "sequence": 6,
+                "amount_select": "code",
+                "amount_python_compute": "result = 0",
+            }
+        )
+        self.developer_pay_structure.write({"rule_ids": [(4, self.test_rule.id)]})
+
+    def test_python_code_return_values(self):
+
+        self.test_rule.amount_python_compute = (
+            "result_rate = 0\n" "result_qty = 0\n" "result = 0"
+        )
+
+        # Open contracts
+        cc = self.env["hr.contract"].search([("employee_id", "=", self.richard_emp.id)])
+        cc.kanban_state = "done"
+        self.env.ref(
+            "hr_contract.ir_cron_data_contract_update_state"
+        ).method_direct_trigger()
+
+        # Create payslip and compute
+        payslip = self.Payslip.create({"employee_id": self.richard_emp.id})
+        payslip.onchange_employee()
+        payslip.compute_sheet()
+
+        line = payslip.line_ids.filtered(lambda l: l.code == "TEST")
+        self.assertEqual(len(line), 1, "I found the Test line")
+        self.assertEqual(line.amount, 0.0, "The amount is zero")
+        self.assertEqual(line.rate, 0.0, "The rate is zero")
+        self.assertEqual(line.quantity, 0.0, "The quantity is zero")


### PR DESCRIPTION
A side effect of the way the payslip line quantity and rate are set when
amount_select is set to "code" causes them to never evaluate to zero. When they
evaluate to 0 the side effect causes them to be set to 1.0 and 100.0, respectively.

    "result_qty" in localdict and localdict["result_qty"] or 1.0
    "result_rate" in localdict and localdict["result_rate"] or 100.0