### PR TITLE
[14.0] [IMP] payroll: refactor of local dictionary handling in payslip for salary rule processing

### DIFF
--- a/payroll/models/hr_salary_rule.py
+++ b/payroll/models/hr_salary_rule.py
@@ -75,6 +75,8 @@ class HrSalaryRule(models.Model):
             #    (sum of amount of all rules belonging to that category).
             # worked_days: object containing the computed worked days
             # inputs: object containing the computed inputs
+            # payroll: object containing miscellaneous values related to payroll
+            # current_contract: object with values calculated from the current contract
 
             # Note: returned value have to be set in the variable 'result'
 
@@ -119,6 +121,8 @@ class HrSalaryRule(models.Model):
             #    (sum of amount of all rules belonging to that category).
             # worked_days: object containing the computed worked days.
             # inputs: object containing the computed inputs.
+            # payroll: object containing miscellaneous values related to payroll
+            # current_contract: object with values calculated from the current contract
 
             # Note: returned value have to be set in the variable 'result'
 

--- a/payroll/tests/__init__.py
+++ b/payroll/tests/__init__.py
@@ -1,4 +1,5 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from . import test_browsable_object
 from . import test_hr_salary_rule
 from . import test_payslip_flow

--- a/payroll/tests/test_browsable_object.py
+++ b/payroll/tests/test_browsable_object.py
@@ -1,0 +1,72 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.addons.payroll.models.hr_payslip import BaseBrowsableObject, BrowsableObject
+
+from .common import TestPayslipBase
+
+
+class TestBrowsableObject(TestPayslipBase):
+    def setUp(self):
+        super().setUp()
+
+    def test_init(self):
+
+        obj = BrowsableObject(self.richard_emp.id, {"test": 1}, self.env)
+
+        self.assertEqual(obj.test, 1, "Simple initialization")
+        self.assertEqual(
+            obj.employee_id,
+            self.richard_emp.id,
+            "Employee Id is retrieved successfully",
+        )
+        self.assertEqual(obj.env, self.env, "Env is retrieved successfully")
+
+        d = {
+            "level1": BaseBrowsableObject(
+                {
+                    "level2": 10,
+                    "env": 900.0,
+                },
+            )
+        }
+        obj = BrowsableObject(self.richard_emp.id, d, self.env)
+
+        self.assertEqual(obj.level1.level2, 10, "Nested initialization")
+        self.assertEqual(
+            obj.employee_id,
+            self.richard_emp.id,
+            "Employee Id is retrieved successfully from nested dictionary",
+        )
+        self.assertEqual(
+            obj.env, self.env, "Env is retrieved successfully from nested dictionary"
+        )
+        self.assertEqual(
+            obj.level1.employee_id, 0.0, "Employee Id is *NOT* in BaseBrowsableObject"
+        )
+        self.assertEqual(
+            obj.level1.env,
+            900.0,
+            "Env is *IN* BaseBrowsableObject, but it's in user-defined dictionary",
+        )
+
+    def test_update_attribute(self):
+
+        obj = BrowsableObject(
+            self.richard_emp.id,
+            {
+                "foo": BaseBrowsableObject(
+                    {
+                        "bar": 200.0,
+                    }
+                )
+            },
+            self.env,
+        )
+        self.assertEqual(obj.foo.bar, 200.0, "Nested initialization succeeded")
+
+        obj.foo.bar = 350.0
+        self.assertEqual(
+            obj.foo.bar,
+            350.0,
+            "Updating of attribute using dot ('.') notation succeeded",
+        )

--- a/payroll/tests/test_payslip_flow.py
+++ b/payroll/tests/test_payslip_flow.py
@@ -7,6 +7,20 @@ from .common import TestPayslipBase
 
 
 class TestPayslipFlow(TestPayslipBase):
+    def setUp(self):
+        super().setUp()
+
+        self.test_rule = self.SalaryRule.create(
+            {
+                "name": "Test rule",
+                "code": "TEST",
+                "category_id": self.categ_alw.id,
+                "sequence": 5,
+                "amount_select": "code",
+                "amount_python_compute": "result = contract.wage",
+            }
+        )
+
     def test_00_payslip_flow(self):
         """Testing payslip flow and report printing"""
 
@@ -114,4 +128,26 @@ class TestPayslipFlow(TestPayslipBase):
             "action_payslip_lines_contribution_register",
             context=context,
             our_module="payroll",
+        )
+
+    def test_contract_qty(self):
+
+        # I set the test rule to detect contract count
+        self.test_rule.amount_python_compute = (
+            "result = payroll.contracts and payroll.contracts.count or -1.0"
+        )
+        self.developer_pay_structure.write({"rule_ids": [(4, self.test_rule.id)]})
+
+        # I put all eligible contracts (including Richard's) in an "open" state
+        self.apply_contract_cron()
+
+        # I create an employee Payslip and process it
+        richard_payslip = self.Payslip.create({"employee_id": self.richard_emp.id})
+        richard_payslip.onchange_employee()
+        richard_payslip.compute_sheet()
+
+        line = richard_payslip.line_ids.filtered(lambda l: l.code == "TEST")
+        self.assertEqual(len(line), 1, "I found the Test line")
+        self.assertEqual(
+            line[0].amount, 1.0, "The calculated dictionary value 'contracts.qty' is 1"
         )


### PR DESCRIPTION
Any serious attempt at implementing a "real" payroll solution with Odoo will eventually require a way of injecting values into the payslip processing rules. At the same time we don't want people running full-blown python code against the Odoo ORM from a payslip rule. That is just an invitation for disaster during one of the most critical jobs of an ERP. So, the ideal solution will allow a module's author to inject discreet values (pieces of information) that can be easily calculated or accessed at run time but doesn't allow the salary rule any more access to the system than it already has.

This PR is an attempt to port my own customizations in this area in a more generalized form. The basic idea is to use the `baselocaldict` dictionary and the `BrowsableObject` python class to allow module authors to add their own nested
dictionaries that can be accessed during salary rule processing. There are two ways they can do this:
1. During loading of values for the payslip lines
2. Once for each contract processed in the payslip (for values that depend on the current contract being processed)

An example of the first kind can include but is not limited to:
1. The total number of contracts for the employee during this payslip
2. Calculation of values based on the previous periods payslip. For example, I use
this mecahnism to calculate the previous payslip's 'NET' value and generate a note
if there is a wide variance.

An example of the second kind is:
1. Hourly wage calculated based on the wage field in the contract