### PR TITLE
[14.0] [IMP] payroll: payslip refactoring 

### DIFF
--- a/payroll/models/hr_payslip.py
+++ b/payroll/models/hr_payslip.py
@@ -143,7 +143,7 @@ class HrPayslip(models.Model):
         required=True,
         default=lambda self: fields.Date.to_string(date.today().replace(day=1)),
         states={"draft": [("readonly", False)]},
-        tracking=1,
+        tracking=True,
     )
     date_to = fields.Date(
         string="Date To",
@@ -153,7 +153,7 @@ class HrPayslip(models.Model):
             (datetime.now() + relativedelta(months=+1, day=1, days=-1)).date()
         ),
         states={"draft": [("readonly", False)]},
-        tracking=1,
+        tracking=True,
     )
     # this is chaos: 4 states are defined, 3 are used ('verify' isn't) and 5
     # exist ('confirm' seems to have existed)
@@ -169,7 +169,7 @@ class HrPayslip(models.Model):
         readonly=True,
         copy=False,
         default="draft",
-        tracking=1,
+        tracking=True,
         help="""* When the payslip is created the status is \'Draft\'
         \n* If the payslip is under verification, the status is \'Waiting\'.
         \n* If the payslip is confirmed then status is set to \'Done\'.
@@ -212,12 +212,16 @@ class HrPayslip(models.Model):
         states={"draft": [("readonly", False)]},
     )
     note = fields.Text(
-        string="Internal Note", readonly=True, states={"draft": [("readonly", False)]}
+        string="Internal Note",
+        readonly=True,
+        states={"draft": [("readonly", False)]},
+        tracking=True,
     )
     contract_id = fields.Many2one(
         "hr.contract",
         string="Contract",
         readonly=True,
+        tracking=True,
         states={"draft": [("readonly", False)]},
     )
     details_by_salary_rule_category = fields.One2many(
@@ -236,6 +240,7 @@ class HrPayslip(models.Model):
         string="Payslip Batches",
         readonly=True,
         copy=False,
+        tracking=True,
         states={"draft": [("readonly", False)]},
     )
     payslip_count = fields.Integer(
@@ -351,77 +356,100 @@ class HrPayslip(models.Model):
         applied for the given contract between date_from and date_to
         """
         res = []
-        # fill only if the contract as a working schedule linked
         for contract in contracts.filtered(
             lambda contract: contract.resource_calendar_id
         ):
-            # Adds support for the hr_public_holidays module.
-            # This adds support to exclude public holidays from work days computation.
-            # If you don't use the module, it don't make any difference or harm.
-            contract = contract.with_context(
-                employee_id=self.employee_id.id, exclude_public_holidays=True
-            )
             day_from = datetime.combine(date_from, time.min)
             day_to = datetime.combine(date_to, time.max)
             day_contract_start = datetime.combine(contract.date_start, time.min)
+            # Support for the hr_public_holidays module.
+            contract = contract.with_context(
+                employee_id=self.employee_id.id, exclude_public_holidays=True
+            )
             # only use payslip day_from if it's greather than contract start date
             if day_from < day_contract_start:
                 day_from = day_contract_start
+            # == compute leave days == #
+            leaves = self._compute_leave_days(contract, day_from, day_to)
+            res.extend(leaves)
+            # == compute worked days == #
+            attendances = self._compute_worked_days(contract, day_from, day_to)
+            res.append(attendances)
+        return res
 
-            # compute leave days
-            leaves = {}
-            calendar = contract.resource_calendar_id
-            tz = timezone(calendar.tz)
-            day_leave_intervals = contract.employee_id.list_leaves(
-                day_from, day_to, calendar=contract.resource_calendar_id
+    def _compute_leave_days(self, contract, day_from, day_to):
+        """
+        Leave days computation
+        @return: returns a list containing the leave inputs for the period
+        of the payslip. One record per leave type.
+        """
+        leaves = {}
+        calendar = contract.resource_calendar_id
+        tz = timezone(calendar.tz)
+        day_leave_intervals = contract.employee_id.list_leaves(
+            day_from, day_to, calendar=contract.resource_calendar_id
+        )
+        for day, hours, leave in day_leave_intervals:
+            holiday = leave[:1].holiday_id
+            current_leave_struct = leaves.setdefault(
+                holiday.holiday_status_id,
+                {
+                    "name": holiday.holiday_status_id.name or _("Global Leaves"),
+                    "sequence": 5,
+                    "code": holiday.holiday_status_id.code or "GLOBAL",
+                    "number_of_days": 0.0,
+                    "number_of_hours": 0.0,
+                    "contract_id": contract.id,
+                },
             )
-            for day, hours, leave in day_leave_intervals:
-                holiday = leave[:1].holiday_id
-                current_leave_struct = leaves.setdefault(
-                    holiday.holiday_status_id,
-                    {
-                        "name": holiday.holiday_status_id.name or _("Global Leaves"),
-                        "sequence": 5,
-                        "code": holiday.holiday_status_id.code or "GLOBAL",
-                        "number_of_days": 0.0,
-                        "number_of_hours": 0.0,
-                        "contract_id": contract.id,
-                    },
-                )
-                current_leave_struct["number_of_hours"] -= hours
-                work_hours = calendar.get_work_hours_count(
-                    tz.localize(datetime.combine(day, time.min)),
-                    tz.localize(datetime.combine(day, time.max)),
-                    compute_leaves=False,
-                )
-                if work_hours:
-                    current_leave_struct["number_of_days"] -= hours / work_hours
-
-            # compute worked days
-            work_data = contract.employee_id._get_work_days_data(
-                day_from,
-                day_to,
-                calendar=contract.resource_calendar_id,
+            current_leave_struct["number_of_hours"] -= hours
+            work_hours = calendar.get_work_hours_count(
+                tz.localize(datetime.combine(day, time.min)),
+                tz.localize(datetime.combine(day, time.max)),
                 compute_leaves=False,
             )
-            attendances = {
-                "name": _("Normal Working Days paid at 100%"),
-                "sequence": 1,
-                "code": "WORK100",
-                "number_of_days": work_data["days"],
-                "number_of_hours": work_data["hours"],
-                "contract_id": contract.id,
-            }
+            if work_hours:
+                current_leave_struct["number_of_days"] -= hours / work_hours
+        return leaves.values()
 
-            res.append(attendances)
-            res.extend(leaves.values())
-        return res
+    def _compute_worked_days(self, contract, day_from, day_to):
+        """
+        Worked days computation
+        @return: returns a list containing the total worked_days for the period
+        of the payslip. This returns the FULL work days expected for the resource
+        calendar selected for the employee (it don't substract leaves by default).
+        """
+        work_data = contract.employee_id._get_work_days_data(
+            day_from,
+            day_to,
+            calendar=contract.resource_calendar_id,
+            compute_leaves=False,
+        )
+        return {
+            "name": _("Normal Working Days paid at 100%"),
+            "sequence": 1,
+            "code": "WORK100",
+            "number_of_days": work_data["days"],
+            "number_of_hours": work_data["hours"],
+            "contract_id": contract.id,
+        }
 
     @api.model
     def get_inputs(self, contracts, date_from, date_to):
+        # TODO: We leave date_from and date_to params here for backwards
+        # compatibility reasons for the ones who inherit this function
+        # in another modules, but they are not used.
+        # Will be removed in next versions.
+        """
+        Inputs computation.
+        @returns: Returns a dict with the inputs that are fetched from the salary_structure
+        associated rules for the given contracts.
+        """
         res = []
-
+        current_structure = self.struct_id
         structure_ids = contracts.get_all_structures()
+        if current_structure:
+            structure_ids = list(set(current_structure._get_parent_structure().ids))
         rule_ids = (
             self.env["hr.payroll.structure"].browse(structure_ids).get_all_rules()
         )
@@ -429,7 +457,6 @@ class HrPayslip(models.Model):
         payslip_inputs = (
             self.env["hr.salary.rule"].browse(sorted_rule_ids).mapped("input_ids")
         )
-
         for contract in contracts:
             for payslip_input in payslip_inputs:
                 res.append(
@@ -641,65 +668,49 @@ class HrPayslip(models.Model):
         return list(result_dict.values())
 
     def get_payslip_vals(
-        self, date_from, date_to, employee_id=False, contract_id=False
+        self, date_from, date_to, employee_id=False, contract_id=False, struct_id=False
     ):
-        # defaults
+        # Initial default values for generated payslips
+        employee = self.env["hr.employee"].browse(employee_id)
         res = {
             "value": {
                 "line_ids": [],
-                # delete old input lines
                 "input_line_ids": [(2, x) for x in self.input_line_ids.ids],
-                # delete old worked days lines
                 "worked_days_line_ids": [(2, x) for x in self.worked_days_line_ids.ids],
-                # 'details_by_salary_head':[], TODO put me back
                 "name": "",
                 "contract_id": False,
                 "struct_id": False,
             }
         }
+
+        # If we don't have employee or date data, we return.
         if (not employee_id) or (not date_from) or (not date_to):
             return res
-        ttyme = datetime.combine(date_from, time.min)
-        employee = self.env["hr.employee"].browse(employee_id)
-        locale = self.env.context.get("lang") or "en_US"
-        res["value"].update(
-            {
-                "name": _("Salary Slip of %s for %s")
-                % (
-                    employee.name,
-                    tools.ustr(
-                        babel.dates.format_date(
-                            date=ttyme, format="MMMM-y", locale=locale
-                        )
-                    ),
-                ),
-                "company_id": employee.company_id.id,
-            }
-        )
-
+        # We check if contract_id is present, if not we fill with the
+        # first contract of the employee. If not contract present, we return.
         if not self.env.context.get("contract"):
-            # fill with the first contract of the employee
             contract_ids = employee.contract_id.ids
         else:
             if contract_id:
-                # set the list of contract for which the input have to be filled
                 contract_ids = [contract_id]
             else:
-                # if we don't give the contract, then the input to fill should
-                # be for all current contracts of the employee
                 contract_ids = employee._get_contracts(
                     date_from=date_from, date_to=date_to
                 ).ids
-
         if not contract_ids:
             return res
         contract = self.env["hr.contract"].browse(contract_ids[0])
         res["value"].update({"contract_id": contract.id})
-        struct = contract.struct_id
-        if not struct:
-            return res
-        res["value"].update({"struct_id": struct.id})
-        # computation of the salary input
+        # We check if struct_id is already filled, otherwise we assign the contract struct.
+        # If contract don't have a struct, we return.
+        if struct_id:
+            res["value"].update({"struct_id": struct_id[0]})
+        else:
+            struct = contract.struct_id
+            if not struct:
+                return res
+            res["value"].update({"struct_id": struct.id})
+        # Computation of the salary input and worked_day_lines
         contracts = self.env["hr.contract"].browse(contract_ids)
         worked_days_line_ids = self.get_worked_day_lines(contracts, date_from, date_to)
         input_line_ids = self.get_inputs(contracts, date_from, date_to)
@@ -711,55 +722,74 @@ class HrPayslip(models.Model):
         )
         return res
 
-    @api.onchange("employee_id", "date_from", "date_to", "struct_id")
-    def onchange_employee(self):
-
-        if (not self.employee_id) or (not self.date_from) or (not self.date_to):
-            return
-
-        employee = self.employee_id
-        date_from = self.date_from
-        date_to = self.date_to
-        contract_ids = self.contract_id.ids
-
-        ttyme = datetime.combine(date_from, time.min)
-        locale = self.env.context.get("lang") or "en_US"
-        self.name = _("Salary Slip of %s for %s") % (
-            employee.name,
-            tools.ustr(
-                babel.dates.format_date(date=ttyme, format="MMMM-y", locale=locale)
-            ),
-        )
-        self.company_id = employee.company_id
-
-        if not self.env.context.get("contract") or not self.contract_id:
-            contract_ids = employee._get_contracts(
-                date_from=date_from, date_to=date_to
+    def _get_employee_contracts(self):
+        return self.env["hr.contract"].browse(
+            self.employee_id._get_contracts(
+                date_from=self.date_from, date_to=self.date_to
             ).ids
-            if not contract_ids:
-                return
-            self.contract_id = self.env["hr.contract"].browse(contract_ids[0])
+        )
 
-        if not self.contract_id.struct_id:
-            return
-
+    @api.onchange("struct_id")
+    def onchange_struct_id(self):
         if not self.struct_id:
-            self.struct_id = self.contract_id.struct_id
-
-        # computation of the salary input
-        contracts = self.env["hr.contract"].browse(contract_ids)
-        worked_days_line_ids = self.get_worked_day_lines(contracts, date_from, date_to)
-        worked_days_lines = self.worked_days_line_ids.browse([])
-        for r in worked_days_line_ids:
-            worked_days_lines += worked_days_lines.new(r)
-        self.worked_days_line_ids = worked_days_lines
-
-        input_line_ids = self.get_inputs(contracts, date_from, date_to)
+            self.input_line_ids.unlink()
+            return
         input_lines = self.input_line_ids.browse([])
+        input_line_ids = self.get_inputs(
+            self._get_employee_contracts(), self.date_from, self.date_to
+        )
         for r in input_line_ids:
             input_lines += input_lines.new(r)
         self.input_line_ids = input_lines
-        return
+
+    @api.onchange("date_from", "date_to")
+    def onchange_dates(self):
+        if not self.date_from or not self.date_to:
+            return
+        worked_days_lines = self.worked_days_line_ids.browse([])
+        worked_days_line_ids = self.get_worked_day_lines(
+            self._get_employee_contracts(), self.date_from, self.date_to
+        )
+        for line in worked_days_line_ids:
+            worked_days_lines += worked_days_lines.new(line)
+        self.worked_days_line_ids = worked_days_lines
+
+    @api.onchange("employee_id", "date_from", "date_to")
+    def onchange_employee(self):
+        # Return if required values are not present.
+        if (not self.employee_id) or (not self.date_from) or (not self.date_to):
+            return
+        # Assign contract_id automatically when the user don't selected one.
+        if not self.env.context.get("contract") or not self.contract_id:
+            contract_ids = self._get_employee_contracts().ids
+            if not contract_ids:
+                return
+            self.contract_id = self.env["hr.contract"].browse(contract_ids[0])
+        # Assign struct_id automatically when the user don't selected one.
+        if not self.struct_id and not self.env.context.get("struct_id"):
+            if not self.contract_id.struct_id:
+                return
+            self.struct_id = self.contract_id.struct_id
+        # Compute payslip name
+        self._compute_name()
+        # Call worked_days_lines computation when employee is changed.
+        self.onchange_dates()
+        # Call input_lines computation when employee is changed.
+        self.onchange_struct_id()
+        # Assign company_id automatically based on employee selected.
+        self.company_id = self.employee_id.company_id
+
+    def _compute_name(self):
+        self.name = _("Salary Slip of %s for %s") % (
+            self.employee_id.name,
+            tools.ustr(
+                babel.dates.format_date(
+                    date=datetime.combine(self.date_from, time.min),
+                    format="MMMM-y",
+                    locale=self.env.context.get("lang") or "en_US",
+                )
+            ),
+        )
 
     @api.onchange("contract_id")
     def onchange_contract(self):

--- a/payroll/models/hr_payslip_run.py
+++ b/payroll/models/hr_payslip_run.py
@@ -52,6 +52,17 @@ class HrPayslipRun(models.Model):
         help="If its checked, indicates that all payslips generated from here "
         "are refund payslips.",
     )
+    struct_id = fields.Many2one(
+        "hr.payroll.structure",
+        string="Structure",
+        readonly=True,
+        states={"draft": [("readonly", False)]},
+        help="Defines the rules that have to be applied to this payslip batch, "
+        "accordingly to the contract chosen. If you let empty the field "
+        "contract, this field isn't mandatory anymore and thus the rules "
+        "applied will be all the rules set on the structure of all contracts "
+        "of the employee valid for the chosen period",
+    )
 
     def draft_payslip_run(self):
         return self.write({"state": "draft"})

--- a/payroll/views/hr_payslip_run_views.xml
+++ b/payroll/views/hr_payslip_run_views.xml
@@ -126,11 +126,22 @@
                     <group col="4">
                         <label for="date_start" string="Period" />
                         <div>
-                            <field name="date_start" class="oe_inline" />
+                            <field
+                                name="date_start"
+                                widget="daterange"
+                                class="oe_inline"
+                                options="{'related_end_date': 'date_end'}"
+                            />
                             -
-                            <field name="date_end" class="oe_inline" />
+                            <field
+                                name="date_end"
+                                widget="daterange"
+                                class="oe_inline"
+                                options="{'related_start_date': 'date_start'}"
+                            />
                         </div>
                         <field name="credit_note" />
+                        <field name="struct_id" />
                     </group>
                     <separator string="Payslips" />
                     <field name="slip_ids" />

--- a/payroll/views/hr_payslip_views.xml
+++ b/payroll/views/hr_payslip_views.xml
@@ -106,6 +106,12 @@
                         class="oe_highlight"
                     />
                     <button
+                        string="Refetch Payslip Data"
+                        name="onchange_employee"
+                        type="object"
+                        states="draft"
+                    />
+                    <button
                         string="Cancel Payslip"
                         name="action_payslip_cancel"
                         type="object"
@@ -142,9 +148,19 @@
                     <group col="4">
                         <label for="date_from" string="Period" />
                         <div>
-                            <field name="date_from" class="oe_inline" />
+                            <field
+                                name="date_from"
+                                widget="daterange"
+                                class="oe_inline"
+                                options="{'related_end_date': 'date_to'}"
+                            />
                             -
-                            <field name="date_to" class="oe_inline" />
+                            <field
+                                name="date_to"
+                                widget="daterange"
+                                class="oe_inline"
+                                options="{'related_start_date': 'date_from'}"
+                            />
                         </div>
                         <field
                             name="contract_id"
@@ -171,7 +187,11 @@
                                         sum="Total Working Days"
                                     />
                                     <field name="number_of_hours" />
-                                    <field name="contract_id" />
+                                    <field
+                                        name="contract_id"
+                                        domain="[('employee_id','=',parent.employee_id),('date_start','&lt;=',parent.date_to),'|',('date_end','&gt;=',parent.date_from),('date_end','=',False)]"
+                                        context="{'default_employee_id': parent.employee_id}"
+                                    />
                                     <field name="sequence" invisible="True" />
                                 </tree>
                                 <form string="Worked Day">
@@ -192,7 +212,11 @@
                                     <field name="code" />
                                     <field name="amount_qty" />
                                     <field name="amount" />
-                                    <field name="contract_id" />
+                                    <field
+                                        name="contract_id"
+                                        domain="[('employee_id','=',parent.employee_id),('date_start','&lt;=',parent.date_to),'|',('date_end','&gt;=',parent.date_from),('date_end','=',False)]"
+                                        context="{'default_employee_id': parent.employee_id}"
+                                    />
                                     <field name="sequence" invisible="True" />
                                 </tree>
                                 <form string="Payslip Line">
@@ -213,15 +237,21 @@
                                     editable="bottom"
                                     decoration-info="total == 0"
                                 >
+                                    <field name="sequence" invisible="1" />
                                     <field name="name" />
                                     <field name="code" />
                                     <field name="category_id" />
-                                    <field name="sequence" invisible="1" />
+                                    <field name="salary_rule_id" />
                                     <field name="quantity" />
                                     <field name="rate" />
-                                    <field name="salary_rule_id" />
                                     <field name="amount" />
-                                    <field name="total" />
+                                    <field
+                                        name="total"
+                                        decoration-bf="1"
+                                        decoration-danger="0 > total"
+                                        decoration-success="total > 0"
+                                        sum="total_net"
+                                    />
                                 </tree>
                                 <form string="Payslip Line">
                                     <group col="4">
@@ -241,6 +271,7 @@
                         <page string="Details By Salary Rule Category">
                             <field
                                 name="details_by_salary_rule_category"
+                                groupby='category_id'
                                 context="{'group_by':'category_id'}"
                                 domain="[('appears_on_payslip', '=', True)]"
                             >
@@ -248,10 +279,15 @@
                                     string="Payslip Lines"
                                     decoration-info="total == 0"
                                 >
-                                    <field name="category_id" />
+                                    <field name="category_id" decoration-bf="1" />
+                                    <field name="code" widget="badge" />
                                     <field name="name" />
-                                    <field name="code" />
-                                    <field name="total" />
+                                    <field
+                                        name="total"
+                                        decoration-bf="1"
+                                        decoration-danger="0 > total"
+                                        decoration-success="total > 0"
+                                    />
                                 </tree>
                             </field>
                         </page>

--- a/payroll/wizard/hr_payroll_payslips_by_employees.py
+++ b/payroll/wizard/hr_payroll_payslips_by_employees.py
@@ -18,15 +18,16 @@ class HrPayslipEmployees(models.TransientModel):
             [run_data] = (
                 self.env["hr.payslip.run"]
                 .browse(active_id)
-                .read(["date_start", "date_end", "credit_note"])
+                .read(["date_start", "date_end", "credit_note", "struct_id"])
             )
         from_date = run_data.get("date_start")
         to_date = run_data.get("date_end")
+        struct_id = run_data.get("struct_id")
         if not data["employee_ids"]:
             raise UserError(_("You must select employee(s) to generate payslip(s)."))
         for employee in self.env["hr.employee"].browse(data["employee_ids"]):
             slip_data = self.env["hr.payslip"].get_payslip_vals(
-                from_date, to_date, employee.id, contract_id=False
+                from_date, to_date, employee.id, contract_id=False, struct_id=struct_id
             )
             res = {
                 "employee_id": employee.id,
@@ -46,5 +47,6 @@ class HrPayslipEmployees(models.TransientModel):
                 "company_id": employee.company_id.id,
             }
             payslips += self.env["hr.payslip"].create(res)
+        payslips._compute_name()
         payslips.compute_sheet()
         return {"type": "ir.actions.act_window_close"}


### PR DESCRIPTION
Hello, in this PR i will be adding commits with the refactoring that i'm doing in hr_payslip. 

Here is the list of what is changed so far (will be editing when i add more commits): 

**Commit: [[IMP] payroll: refactor onchange methods](https://github.com/OCA/payroll/commit/3068f2c1dec6a9a7f65e44fbe9a68703bfc8bc23)**
- Now the get_inputs method takes into account the current struct_id selected. Before that, the function was always taking the struct_id from contract what it's inconvenient because the user couldn't change the struct_id from the payslip. 
- "struct_id" has his own onchange method now, this allows to recompute the inputs table without recomputing all the dynamic fields and losing current data.
- "date_to" and "date_start" fields has his own onchange method now, this allows to recompute the worked_days_lines without recomputing all the dynamic fields and losing current data. 
- New method "_get_employee_contracts" allow to extract the contract fetching logic from the onchange method. This allow not having to call onchange_employee if we want to fetch the contracts in another function. 
- Full refactoring of the onchange_employee method. Before this, this method is used for all the information fetching like worked_hours and inputs. The problem in doing it in only one method is that it's difficult to inherit from another modules and also complicates to change the functions get_inputs and get_worked_days_lines that are constantly inherited by other modules to bring more data to the payslip. Now this method is only in charge of validating the necessary fields for the dynamic fetch and autoasign the dynamic values (contract and struct_id) when we change the employee. 

**Commit:**  [[IMP] payroll: refactor of the method get_worked_day_lines](https://github.com/OCA/payroll/pull/47/commits/618ed3b35fde25dea63ba9dcc3cfa56ffaec0482)[[IMP] payroll: refactor of the method get_worked_day_lines](https://github.com/OCA/payroll/pull/47/commits/618ed3b35fde25dea63ba9dcc3cfa56ffaec0482)
- New method "_compute_worked_days" extracted from get_worked_day_lines. Now is simpler to inherit this method if someone wants to make changes in how it calculate worked_hours. 
- New method "_compute_leave_days" extracted from get_worked_day_lines. Now is simpler to inherit this method if someone wants to make changes in how it calculate worked_hours. 
- Refactor of the method "get_worked_day_lines". Now this method only encapsulates the required fields for the data fetching from other models and then call the individual methods for doing such task. This provide more support for custom modules inheriting individual data fetching methods without need to override or copy get_worked_day_lines. Also if anyone wants to add new functions that fetch data from other sources, it will be more easy from another modules. 

**Commit:** [[IMP] payroll: Add domain to contract in many2one tables](https://github.com/OCA/payroll/pull/47/commits/a88c84afadad6d85c995a7335520bde156c3526f)
- Adds domain to contract_id fields in worked_day_lines and input_lines in the payslip form. Before that all contracts were a possible option which not make sense because the payslip is only for one employee. Now the dropdown only shows the contacts for that employee and dates. 

**Commit:** [[IMP] payroll: Add daterange widget for dates](https://github.com/OCA/payroll/pull/47/commits/586a01a8dd63cbee6c7051a503d6ebe7bb466ff6)

Here we add daterange widget which i think makes sense for this type of views. Now you can select the date with a daterange widget which is useful for preventing errors in the dates. 

**Commit:** [[IMP] payroll: Refactor get_payslip_vals and add struct_id selection …](https://github.com/OCA/payroll/pull/47/commits/b12e06cc2b6ec81e5e43845e79d632760b322be2)

This commit refactor the get_payslip_vals used in batch run payslip calculation. Also, we add the possibility to select the salary_structure in the run form, that way we provide the user the option to choose to make the payslips for a structure different of the selected in the contract. Before that, if you use batch computation of payslips, you can only do it for the structure defined on the contract, now, the user can choose which structure use for all payslips at once. 

Will be making more commits soon refactoring other areas of the hr_payslip file. Keep you posted and let you know when is ready for review. If someone wants to test it and give advice is welcomed. 

Regards.