### PR TITLE
[IMP] payroll: allow the use of positive values in leave days/hours c…

### DIFF
--- a/payroll/models/res_config_settings.py
+++ b/payroll/models/res_config_settings.py
@@ -7,3 +7,9 @@ class ResConfigSettings(models.TransientModel):
     _inherit = "res.config.settings"
 
     module_payroll_account = fields.Boolean(string="Payroll Accounting")
+    leaves_positive = fields.Boolean(
+        config_parameter="payroll.leaves_positive",
+        string="Leaves with positive values",
+        help="Values for leaves (days and hours fields) "
+        "should be positive instead of negative.",
+    )

--- a/payroll/tests/__init__.py
+++ b/payroll/tests/__init__.py
@@ -1,5 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import test_browsable_object
+from . import test_hr_payslip_worked_days
 from . import test_hr_salary_rule
 from . import test_payslip_flow

--- a/payroll/tests/common.py
+++ b/payroll/tests/common.py
@@ -14,6 +14,7 @@ class TestPayslipBase(TransactionCase):
         self.RuleInput = self.env["hr.rule.input"]
         self.SalaryRule = self.env["hr.salary.rule"]
         self.SalaryRuleCateg = self.env["hr.salary.rule.category"]
+        self.Contract = self.env["hr.contract"]
 
         # Salary Rule Categories
         #

--- a/payroll/tests/test_hr_payslip_worked_days.py
+++ b/payroll/tests/test_hr_payslip_worked_days.py
@@ -1,0 +1,106 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from datetime import date, datetime
+
+from odoo.tests.common import Form
+
+from .common import TestPayslipBase
+
+
+class TestWorkedDays(TestPayslipBase):
+    def setUp(self):
+        super().setUp()
+
+        self.LeaveRequest = self.env["hr.leave"]
+        self.LeaveType = self.env["hr.leave.type"]
+
+        # create holiday type
+        self.holiday_type = self.LeaveType.create(
+            {
+                "name": "TestLeaveType",
+                "code": "TESTLV",
+                "allocation_type": "no",
+                "leave_validation_type": "no_validation",
+            }
+        )
+
+    def _common_contract_leave_setup(self):
+
+        # I put all eligible contracts (including Richard's) in an "open" state
+        self.apply_contract_cron()
+
+        # Create the leave
+        self.LeaveRequest.create(
+            {
+                "name": "Hol11",
+                "employee_id": self.richard_emp.id,
+                "holiday_status_id": self.holiday_type.id,
+                "date_from": datetime.combine(date.today(), datetime.min.time()),
+                "date_to": datetime.combine(date.today(), datetime.max.time()),
+                "number_of_days": 1,
+            }
+        )
+
+    def test_worked_days_negative(self):
+
+        self._common_contract_leave_setup()
+
+        # Set system parameter
+        self.env["ir.config_parameter"].sudo().set_param(
+            "payroll.leaves_positive", False
+        )
+
+        # I create an employee Payslip
+        frm = Form(self.Payslip)
+        frm.employee_id = self.richard_emp
+        richard_payslip = frm.save()
+
+        worked_days_codes = richard_payslip.worked_days_line_ids.mapped("code")
+        self.assertIn(
+            "TESTLV", worked_days_codes, "The leave is in the 'Worked Days' list"
+        )
+        wdl_ids = richard_payslip.worked_days_line_ids.filtered(
+            lambda x: x.code == "TESTLV"
+        )
+        self.assertEqual(len(wdl_ids), 1, "There is only one line matching the leave")
+        self.assertEqual(
+            wdl_ids[0].number_of_days,
+            -1.0,
+            "The days worked value is a NEGATIVE number",
+        )
+        self.assertEqual(
+            wdl_ids[0].number_of_hours,
+            -8.0,
+            "The hours worked value is a NEGATIVE number",
+        )
+
+    def test_leaves_positive(self):
+
+        self._common_contract_leave_setup()
+
+        # Set system parameter
+        self.env["ir.config_parameter"].sudo().set_param(
+            "payroll.leaves_positive", True
+        )
+
+        # I create an employee Payslip
+        frm = Form(self.Payslip)
+        frm.employee_id = self.richard_emp
+        richard_payslip = frm.save()
+
+        worked_days_codes = richard_payslip.worked_days_line_ids.mapped("code")
+        self.assertIn(
+            "TESTLV", worked_days_codes, "The leave is in the 'Worked Days' list"
+        )
+        wdl_ids = richard_payslip.worked_days_line_ids.filtered(
+            lambda x: x.code == "TESTLV"
+        )
+        self.assertEqual(len(wdl_ids), 1, "There is only one line matching the leave")
+        self.assertEqual(
+            wdl_ids[0].number_of_days, 1.0, "The days worked value is a POSITIVE number"
+        )
+        self.assertEqual(
+            wdl_ids[0].number_of_hours,
+            8.0,
+            "The hours worked value is a POSITIVE number",
+        )

--- a/payroll/views/res_config_settings_views.xml
+++ b/payroll/views/res_config_settings_views.xml
@@ -41,6 +41,20 @@
                             </div>
                         </div>
                     </div>
+                    <h2>Worked Days</h2>
+                    <div class="row mt16 o_settings_container" id="worked_days">
+                        <div class="col-lg-6 col-12 o_setting_box">
+                            <div class="o_setting_left_pane">
+                                <field name="leaves_positive" />
+                            </div>
+                            <div class="o_setting_right_pane">
+                                <label for="leaves_positive" />
+                                <div class="text-muted">
+                                    Display non-negative values for leaves in payslip worked days lines.
+                                </div>
+                            </div>
+                        </div>
+                    </div>
                 </div>
             </xpath>
         </field>


### PR DESCRIPTION
This is controlled by a new system parameter in Payroll Settings. The default is off. But when set to true leave days and hours will no longer appear as negative numbers. There are two reasons why someone might want this.

First, the idea that the sum of worked days and leave days should equal the number of actual days worked is **NOT** correct. A trivial example is if we are tracking overtime.  For example, let's say Sally worked only two days this month. The first day she worked a normal 8 hours, but the second day she worked an extra 2 hours of overtime (total 10 hours). In this case the worked days lines would look like this:

| Description                |   Code        | No. of Days | No. of Hours |
| --------------------------- |  -------------- | ---------------- | ----------------- |
| Normal Hours 100% |  WORK100 |           2        |           16       |
| Overtime                   |   OT            |           1        |             2       |
|Sum                           |                    |           3        |                     |

So according to this simplistic view Sally worked for 3 days this month when this is patently false. This is only one trivial example and there are many more. For example, some leaves may be paid leaves that by law cannot be deducted from pay (so for payroll purposes it should be treated as a worked day).

The second reason is more of a philosophical objection but leads back to the first. The payroll code should only give back or display the magnitude (or absolute value) of a number. It's up to the human (through salary rules) to decide whether it should be treated as a negative or positive number. The programmer should not force his/her own mental model onto the user. This is **WRONG.** It introduces unnecessary hidden complexity. With the current behavior a salary rule that calculates worked days will look like this: 

`result = worked_days.WORK100.number_of_days + worked_days.SICK.number_of_days`

The following more closely resembles the actual operation the user is trying to do:

`result = worked_days.WORK100.number_of_days - worked_days.SICK.number_of_days`
