### PR TITLE
[14.0][FIX] payroll_account: log a warning if no move lines are generated for the payslip

### DIFF
--- a/payroll_account/models/hr_payroll_account.py
+++ b/payroll_account/models/hr_payroll_account.py
@@ -1,7 +1,11 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+import logging
+
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError
+
+logger = logging.getLogger(__name__)
 
 
 class HrPayslipLine(models.Model):
@@ -255,10 +259,15 @@ class HrPayslip(models.Model):
                     },
                 )
                 line_ids.append(adjust_debit)
-            move_dict["line_ids"] = line_ids
-            move = self.env["account.move"].create(move_dict)
-            slip.write({"move_id": move.id, "date": date})
-            move.action_post()
+            if len(line_ids) > 0:
+                move_dict["line_ids"] = line_ids
+                move = self.env["account.move"].create(move_dict)
+                slip.write({"move_id": move.id, "date": date})
+                move.action_post()
+            else:
+                logger.warning(
+                    f"Payslip {slip.number} did not generate any account move lines"
+                )
         return res
 
 


### PR DESCRIPTION
The payroll_account module tries to confirm the account moves for the payslip without verifying that there are actually any account move lines. This causes the account module to throw an exception. I ran into this when one of my module's tests (that has nothing to do with payroll accounting) kept triggering this failure. The payroll_account module test seems to imply that this failure is expected but I think this is wrong because A) it causes other modules that do not know about payroll_account to fail and B) this is a downstream exception in another module and the payroll_account module should not be relying on an exception being thrown in another module.