### PR TITLE
[FIX] payroll: Fix Refactored _compute_name to contemplate more than …

### DIFF
--- a/payroll/models/hr_payslip.py
+++ b/payroll/models/hr_payslip.py
@@ -794,16 +794,17 @@ class HrPayslip(models.Model):
         self.company_id = self.employee_id.company_id
 
     def _compute_name(self):
-        self.name = _("Salary Slip of %s for %s") % (
-            self.employee_id.name,
-            tools.ustr(
-                babel.dates.format_date(
-                    date=datetime.combine(self.date_from, time.min),
-                    format="MMMM-y",
-                    locale=self.env.context.get("lang") or "en_US",
-                )
-            ),
-        )
+        for record in self:
+            record.name = _("Salary Slip of %s for %s") % (
+                record.employee_id.name,
+                tools.ustr(
+                    babel.dates.format_date(
+                        date=datetime.combine(record.date_from, time.min),
+                        format="MMMM-y",
+                        locale=record.env.context.get("lang") or "en_US",
+                    )
+                ),
+            )
 
     @api.onchange("contract_id")
     def onchange_contract(self):


### PR DESCRIPTION
This fix is for the new _compute_name method introduced in last PR. The method was contemplating only one record, so when its called from payslip_run we get an error. 

This fixes it. Will merge directly since it's a easy fix and can be a problem for production installations. 