### PR TITLE
[IMP] payroll: Improve views, add child functionalities, allow compute of name

### DIFF
--- a/payroll/models/hr_payslip_line.py
+++ b/payroll/models/hr_payslip_line.py
@@ -16,6 +16,15 @@ class HrPayslipLine(models.Model):
     payslip_run_id = fields.Many2one(
         "hr.payslip.run", related="slip_id.payslip_run_id", string="Payslip Batch"
     )
+    child_ids = fields.One2many(
+        "hr.payslip.line", "parent_line_id", string="Child Payslip Lines"
+    )
+    parent_line_id = fields.Many2one(
+        "hr.payslip.line",
+        string="Parent Payslip Line",
+        compute="_compute_parent_line_id",
+        store=True,
+    )
     salary_rule_id = fields.Many2one("hr.salary.rule", string="Rule", required=True)
     employee_id = fields.Many2one("hr.employee", string="Employee", required=True)
     contract_id = fields.Many2one(
@@ -30,6 +39,26 @@ class HrPayslipLine(models.Model):
         digits="Payroll",
         store=True,
     )
+
+    @api.depends("parent_rule_id", "contract_id", "slip_id")
+    def _compute_parent_line_id(self):
+        for line in self:
+            if line.parent_rule_id:
+                parent_line = line.slip_id.line_ids.filtered(
+                    lambda l: l.salary_rule_id == line.parent_rule_id
+                    and l.contract_id == line.contract_id
+                    and l.slip_id == line.slip_id
+                )
+                if parent_line and len(parent_line) > 1:
+                    raise UserError(
+                        _("Recursion error. Only one line should be parent of %s")
+                        % line.parent_rule_id.name
+                    )
+                line.parent_line_id = (
+                    parent_line[0].id if len(parent_line) == 1 else False
+                )
+            else:
+                line.parent_line_id = False
 
     @api.depends("quantity", "amount", "rate")
     def _compute_total(self):

--- a/payroll/models/hr_salary_rule.py
+++ b/payroll/models/hr_salary_rule.py
@@ -80,9 +80,15 @@ class HrSalaryRule(models.Model):
             # payroll: object containing miscellaneous values related to payroll
             # current_contract: object with values calculated from the current contract
 
-            # Note: returned value have to be set in the variable 'result'
+            # Available compute variables:
+            #-------------------------------
+            result: returned value have to be set in the variable 'result'
 
-            result = rules.NET > categories.NET * 0.10""",
+            # Example:
+            #-------------------------------
+            result = rules.NET > categories.NET * 0.10
+
+            """,
         help="Applied this rule for calculation if condition is true. You can "
         "specify condition like basic > 1000.",
     )
@@ -114,7 +120,7 @@ class HrSalaryRule(models.Model):
         string="Python Code",
         default="""
             # Available variables:
-            #----------------------
+            #-------------------------------
             # payslip: object containing the payslips
             # employee: hr.employee object
             # contract: hr.contract object
@@ -126,9 +132,18 @@ class HrSalaryRule(models.Model):
             # payroll: object containing miscellaneous values related to payroll
             # current_contract: object with values calculated from the current contract
 
-            # Note: returned value have to be set in the variable 'result'
+            # Available compute variables:
+            #-------------------------------
+            result: returned value have to be set in the variable 'result'
+            result_rate: the rate that will be applied to "result".
+            result_qty: the quantity of units that will be multiplied to "result".
+            result_name: if this variable is computed, it will contain the name of the line.
 
-            result = contract.wage * 0.10""",
+            # Example:
+            #-------------------------------
+            result = contract.wage * 0.10
+
+            """,
     )
     amount_percentage_base = fields.Char(
         string="Percentage based on", help="result will be affected to a variable"
@@ -177,6 +192,7 @@ class HrSalaryRule(models.Model):
                     self.amount_fix,
                     float(safe_eval(self.quantity, localdict)),
                     100.0,
+                    False,  # result_name is always False if not computed by python.
                 )
             except Exception:
                 raise UserError(
@@ -189,6 +205,7 @@ class HrSalaryRule(models.Model):
                     float(safe_eval(self.amount_percentage_base, localdict)),
                     float(safe_eval(self.quantity, localdict)),
                     self.amount_percentage,
+                    False,  # result_name is always False if not computed by python.
                 )
             except Exception:
                 raise UserError(
@@ -205,6 +222,9 @@ class HrSalaryRule(models.Model):
                 )
                 result_qty = 1.0
                 result_rate = 100.0
+                result_name = False
+                if "result_name" in localdict:
+                    result_name = localdict["result_name"]
                 if "result_qty" in localdict:
                     result_qty = localdict["result_qty"]
                 if "result_rate" in localdict:
@@ -213,6 +233,7 @@ class HrSalaryRule(models.Model):
                     float(localdict["result"]),
                     float(result_qty),
                     float(result_rate),
+                    result_name,
                 )
             except Exception as ex:
                 raise UserError(

--- a/payroll/tests/common.py
+++ b/payroll/tests/common.py
@@ -155,6 +155,22 @@ class TestPayslipBase(TransactionCase):
             }
         )
 
+        # Test Child Line
+        #
+        self.rule_child = self.SalaryRule.create(
+            {
+                "name": "Net Child Rule",
+                "code": "NET_CHILD",
+                "sequence": 190,
+                "category_id": self.categ_net.id,
+                "parent_rule_id": self.rule_net.id,
+                "condition_select": "none",
+                "amount_select": "code",
+                "amount_python_compute": "result = categories.BASIC "
+                "+ categories.ALW + categories.DED",
+            }
+        )
+
         # I create a new employee "Richard"
         self.richard_emp = self.env["hr.employee"].create(
             {

--- a/payroll/tests/test_hr_salary_rule.py
+++ b/payroll/tests/test_hr_salary_rule.py
@@ -25,7 +25,7 @@ class TestSalaryRule(TestPayslipBase):
     def test_python_code_return_values(self):
 
         self.test_rule.amount_python_compute = (
-            "result_rate = 0\n" "result_qty = 0\n" "result = 0"
+            "result_rate = 0\n" "result_qty = 0\n" "result = 0\n"
         )
 
         # Open contracts

--- a/payroll/tests/test_payslip_flow.py
+++ b/payroll/tests/test_payslip_flow.py
@@ -53,6 +53,40 @@ class TestPayslipFlow(TestPayslipBase):
         # I click on 'Compute Sheet' button on payslip
         richard_payslip.with_context(context).compute_sheet()
 
+        # Check child rules shown in table by default
+        child_line = richard_payslip.dynamic_filtered_payslip_lines.filtered(
+            lambda l: l.code == "NET_CHILD"
+        )
+        self.assertEqual(
+            len(child_line), 1, "Child line found when flag desactivated (default)"
+        )
+
+        # Check parent line id value is correct
+        parent_line = richard_payslip.dynamic_filtered_payslip_lines.filtered(
+            lambda l: l.code == "NET"
+        )
+        self.assertEqual(
+            child_line.parent_line_id.code,
+            parent_line.code,
+            "Child line parent_id is correct",
+        )
+
+        # Check parent line id is False in a rule that have not parent defined
+        self.assertEqual(
+            len(parent_line.parent_line_id), 0, "The parent line has no parent_line_id"
+        )
+
+        # We change child rules show/hide flag
+        richard_payslip.hide_child_lines = True
+
+        # Check child rules not shown in table after flag changed
+        child_line = richard_payslip.dynamic_filtered_payslip_lines.filtered(
+            lambda l: l.code == "NET_CHILD"
+        )
+        self.assertEqual(
+            len(child_line), 0, "The child line is not found when flag activated"
+        )
+
         # Find the 'NET' payslip line and check that it adds up
         # salary + HRA + MA + SALE - PT
         work100 = richard_payslip.worked_days_line_ids.filtered(
@@ -94,7 +128,6 @@ class TestPayslipFlow(TestPayslipBase):
         )
 
         # I create record for generating the payslip for this Payslip run.
-
         payslip_employee = self.env["hr.payslip.employees"].create(
             {"employee_ids": [(4, self.richard_emp.id)]}
         )

--- a/payroll/views/hr_payslip_line_views.xml
+++ b/payroll/views/hr_payslip_line_views.xml
@@ -29,28 +29,68 @@
         <field name="model">hr.payslip.line</field>
         <field name="arch" type="xml">
             <form string="Payslip Line">
+                <h2>
+                    <field name="slip_id" readonly="1" />
+                </h2>
                 <group>
-                    <group>
+                    <group string="Payslip Line Details">
                         <field name="name" />
-                        <field name="code" />
-                        <field name="slip_id" />
-                        <field name="employee_id" />
+                        <field name="code" readonly="1" />
+                        <field name="employee_id" readonly="1" />
+                        <field name="contract_id" readonly="1" />
                     </group>
                     <group string="Calculations">
-                        <field name="category_id" />
-                        <field name="amount_select" />
+                        <field name="category_id" readonly="1" />
+                        <field name="amount_select" readonly="1" />
                         <field
                             name="amount_fix"
-                            attrs="{'readonly':[('amount_select','!=','fix')]}"
+                            attrs="{'invisible':[('amount_select','!=','fix')]}"
+                            readonly="1"
                         />
                         <field
                             name="amount_percentage"
-                            attrs="{'readonly':[('amount_select','!=','percentage')]}"
+                            attrs="{'invisible':[('amount_select','!=','percentage')]}"
+                            readonly="1"
                         />
-                        <field name="sequence" />
+                        <field name="sequence" readonly="1" />
+                        <separator />
+                        <field name="quantity" readonly="1" />
+                        <field name="rate" readonly="1" />
+                        <field name="amount" readonly="1" />
+                        <field name="total" decoration-bf="1" readonly="1" />
                     </group>
                     <field name="note" />
                 </group>
+                <notebook>
+                    <page name="child_ids" string="Child Line Details">
+                        <group>
+                            <field name="child_ids" readonly="1" nolabel="1">
+                                <tree
+                                    string="Child Salary Structure"
+                                    editable="false"
+                                    decoration-info="total == 0"
+                                    decoration-bf="parent_line_id == False"
+                                >
+                                    <field name="sequence" invisible="1" />
+                                    <field name="parent_line_id" invisible="1" />
+                                    <field name="name" />
+                                    <field name="code" />
+                                    <field name="category_id" />
+                                    <field name="salary_rule_id" />
+                                    <field name="quantity" />
+                                    <field name="rate" />
+                                    <field name="amount" />
+                                    <field
+                                        name="total"
+                                        decoration-danger="0 > total and parent_line_id == False"
+                                        decoration-success="total > 0 and parent_line_id == False"
+                                        sum="total_net"
+                                    />
+                                </tree>
+                            </field>
+                        </group>
+                    </page>
+                </notebook>
             </form>
         </field>
     </record>

--- a/payroll/views/hr_payslip_views.xml
+++ b/payroll/views/hr_payslip_views.xml
@@ -231,50 +231,51 @@
                             </field>
                         </page>
                         <page name="computation" string="Salary Computation">
-                            <field name="line_ids" colspan="4" nolabel="1">
+                            <group>
+                                <field
+                                    name="hide_child_lines"
+                                    widget="boolean_toggle"
+                                />
+                            </group>
+                            <field
+                                name="dynamic_filtered_payslip_lines"
+                                colspan="4"
+                                nolabel="1"
+                            >
                                 <tree
                                     string="Salary Structure"
-                                    editable="bottom"
                                     decoration-info="total == 0"
+                                    decoration-bf="parent_rule_id == False"
+                                    decoration-it="parent_rule_id != False"
+                                    decoration-muted="parent_rule_id != False"
+                                    create="false"
+                                    delete="false"
                                 >
                                     <field name="sequence" invisible="1" />
+                                    <field name="parent_line_id" invisible="1" />
+                                    <field name="parent_rule_id" invisible="1" />
+                                    <field name="code" readonly="1" />
+                                    <field
+                                        name="salary_rule_id"
+                                        readonly="1"
+                                        invisible="1"
+                                    />
+                                    <field name="category_id" readonly="1" />
                                     <field name="name" />
-                                    <field name="code" />
-                                    <field name="category_id" />
-                                    <field name="salary_rule_id" />
-                                    <field name="quantity" />
-                                    <field name="rate" />
-                                    <field name="amount" />
+                                    <field name="quantity" readonly="1" />
+                                    <field name="rate" readonly="1" />
+                                    <field name="amount" readonly="1" />
                                     <field
                                         name="total"
-                                        decoration-bf="1"
-                                        decoration-danger="0 > total"
-                                        decoration-success="total > 0"
-                                        sum="total_net"
+                                        decoration-danger="0 > total and parent_rule_id == False"
+                                        decoration-success="total > 0 and parent_rule_id == False"
+                                        readonly="1"
                                     />
                                 </tree>
-                                <form string="Payslip Line">
-                                    <group col="4">
-                                        <field name="name" />
-                                        <field name="code" />
-                                        <field name="category_id" />
-                                        <field name="sequence" />
-                                        <field name="quantity" />
-                                        <field name="rate" />
-                                        <field name="amount" />
-                                        <field name="total" />
-                                        <field name="salary_rule_id" />
-                                    </group>
-                                </form>
                             </field>
                         </page>
-                        <page name="details" string="Details By Salary Rule Category">
-                            <field
-                                name="details_by_salary_rule_category"
-                                groupby='category_id'
-                                context="{'group_by':'category_id'}"
-                                domain="[('appears_on_payslip', '=', True)]"
-                            >
+                        <page name="details" string="Salary rules apearing on payslip">
+                            <field name="details_by_salary_rule_category">
                                 <tree
                                     string="Payslip Lines"
                                     decoration-info="total == 0"

--- a/payroll/views/hr_salary_rule_views.xml
+++ b/payroll/views/hr_salary_rule_views.xml
@@ -169,6 +169,17 @@
                         </group>
                     </page>
                     <page name="rules" string="Child Rules">
+                        <div class="alert alert-info" role="alert">
+                            <p>
+                                Child rule functionality is useful when you need other rules to be computed before the parent one. <br
+                                />
+                                This means that all salary rules declared as childs (parent of one rule) will be added to the computation
+                                if its parent rule is included in the salary structure. So child rules will only be computed if it's parent is
+                                computed. <br />
+                                This functionality is useful for doing auxiliar calculations that are used as dependencies for the parent
+                                salary rule (e.x. rules required for complex tax computation that needs data from several modules).
+                            </p>
+                        </div>
                         <field name="parent_rule_id" />
                         <separator string="Children Definition" />
                         <field name="child_ids" />


### PR DESCRIPTION
Hello friends, 

This PR brings the following changes to the payroll module: 

1.  Improvements to the views and forms of hr_payslip and hr_payslip_line 

2. As is done in enterprise, payslip_lines should not be available to edit manually, also the table should not allow introducing the lines manually. This is fixed in that PR. As the table can no be edited anymore, this allows us to do any computation and conditions to the table to allow functionalities like the next one. So #29 is now fixed since the module now don't let manually add lines, they should be always computed by the module. 

3. Support child and parent salary rules in form and allowing more functionality. Now child salary rules are differentiated in the computation table (with muted color and bold the parent ones, see images), also if you click on one line to open it's associated form, you can now see a table with the associated lines of that payslip (this is done doing a recursive relation by the field parent_rule_id). 
Before this change, the functionality of child and parent rules was trivial, since they has no impact in the calculation and lines generated are not differentiated in any way. This allows the user to use child and parent salary rules as auxiliar calculations for the parent salary rule and also see them in the table or in the associated payslip_line form allowing an analytic a easy way to review a payslip. Finally we have a flag boolean field on top of the table that allow the user to hide/show the child rules as his wish. 

4. Now details_by_salary_rule_category is filtered by appears_on_payslip. That allow to use that table to have a view of the actual lines that compose the payslip and it's report. TODO: Probably we should change the name of the tab, i accept suggestions about this. The method i leave the same name (details_by_salary_rule_category) to preserve backward compatibility with private modules that might be using it. 

5. I introduce the variable "result_name" available for computation in python computed salary rules. The result_name variable allows the user to use a python code to compute a name, and this name is propagated to the payslip_line name. This is useful for use cases when a payslip_line should change its name depending of a condition, or when you want to display some employee specific information in the line name. If variable is not used or it's value is "False", the default salary_rule name will be used as always. 

Hope you like the new changes, and i accept suggestions if you have an idea to make it even better. I think that they are very useful functionalities for the module to have. Hope you test it soon and let me know. 

