### PR TITLE
[IMP] Payroll: Payslip refactoring and misc functionalies

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 # payroll
 
-TODO: add repo description.
+Modules to manage payroll in odoo.
 
 <!-- /!\ do not modify below this line -->
 

--- a/hr_payroll_cancel/__manifest__.py
+++ b/hr_payroll_cancel/__manifest__.py
@@ -19,5 +19,6 @@
     "data": [
         "views/hr_payslip_view.xml",
     ],
+    "maintainers": ["appstogrow", "nimarosa"],
     "installable": True,
 }

--- a/hr_payslip_change_state/__manifest__.py
+++ b/hr_payslip_change_state/__manifest__.py
@@ -14,5 +14,6 @@
         "wizard/hr_payslip_change_state_view.xml",
         "security/ir.model.access.csv",
     ],
+    "maintainers": ["appstogrow", "nimarosa"],
     "installable": True,
 }

--- a/hr_payslip_change_state/tests/test_hr_payslip_change_state.py
+++ b/hr_payslip_change_state/tests/test_hr_payslip_change_state.py
@@ -29,8 +29,8 @@ class TestHrPayslipChangeState(TestHrPayrollCancel):
             action.write({"state": "draft"})
             action.change_state_confirm()
 
-        # Now the payslip should be computed but in state draft
-        self.assertEqual(hr_payslip.state, "draft")
+        # Now the payslip should be computed but in verify state
+        self.assertEqual(hr_payslip.state, "verify")
         self.assertNotEqual(hr_payslip.number, None)
         action.write({"state": "done"})
         action.change_state_confirm()

--- a/hr_payslip_change_state/wizard/hr_payslip_change_state.py
+++ b/hr_payslip_change_state/wizard/hr_payslip_change_state.py
@@ -45,7 +45,7 @@ class HrPayslipChangeState(models.TransientModel):
                         )
                     )
             elif new_state == "verify":
-                if rec.state == "draft":
+                if rec.state in ["draft", "verify"]:
                     rec.compute_sheet()
                 else:
                     raise UserError(

--- a/payroll/models/__init__.py
+++ b/payroll/models/__init__.py
@@ -7,6 +7,7 @@ from . import hr_salary_rule
 from . import hr_salary_rule_category
 from . import hr_rule_input
 from . import hr_contribution_register
+from . import base_browsable
 from . import hr_payslip
 from . import hr_payslip_line
 from . import hr_payslip_input

--- a/payroll/models/base_browsable.py
+++ b/payroll/models/base_browsable.py
@@ -1,0 +1,102 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import fields
+
+
+class BaseBrowsableObject(object):
+    def __init__(self, vals_dict):
+        self.__dict__["base_fields"] = ["base_fields", "dict"]
+        self.dict = vals_dict
+
+    def __getattr__(self, attr):
+        return attr in self.dict and self.dict.__getitem__(attr) or 0.0
+
+    def __setattr__(self, attr, value):
+        _fields = self.__dict__["base_fields"]
+        if attr in _fields:
+            return super().__setattr__(attr, value)
+        self.__dict__["dict"][attr] = value
+
+    def __str__(self):
+        return str(self.__dict__)
+
+
+# These classes are used in the _get_payslip_lines() method
+class BrowsableObject(BaseBrowsableObject):
+    def __init__(self, employee_id, vals_dict, env):
+        super().__init__(vals_dict)
+        self.base_fields += ["employee_id", "env"]
+        self.employee_id = employee_id
+        self.env = env
+
+
+class InputLine(BrowsableObject):
+    """a class that will be used into the python code, mainly for
+    usability purposes"""
+
+    def sum(self, code, from_date, to_date=None):
+        if to_date is None:
+            to_date = fields.Date.today()
+        self.env.cr.execute(
+            """
+            SELECT sum(amount) as sum
+            FROM hr_payslip as hp, hr_payslip_input as pi
+            WHERE hp.employee_id = %s AND hp.state = 'done'
+            AND hp.date_from >= %s AND hp.date_to <= %s
+            AND hp.id = pi.payslip_id AND pi.code = %s""",
+            (self.employee_id, from_date, to_date, code),
+        )
+        return self.env.cr.fetchone()[0] or 0.0
+
+
+class WorkedDays(BrowsableObject):
+    """a class that will be used into the python code, mainly for
+    usability purposes"""
+
+    def _sum(self, code, from_date, to_date=None):
+        if to_date is None:
+            to_date = fields.Date.today()
+        self.env.cr.execute(
+            """
+            SELECT sum(number_of_days) as number_of_days,
+             sum(number_of_hours) as number_of_hours
+            FROM hr_payslip as hp, hr_payslip_worked_days as pi
+            WHERE hp.employee_id = %s AND hp.state = 'done'
+            AND hp.date_from >= %s AND hp.date_to <= %s
+            AND hp.id = pi.payslip_id AND pi.code = %s""",
+            (self.employee_id, from_date, to_date, code),
+        )
+        return self.env.cr.fetchone()
+
+    def sum(self, code, from_date, to_date=None):
+        res = self._sum(code, from_date, to_date)
+        return res and res[0] or 0.0
+
+    def sum_hours(self, code, from_date, to_date=None):
+        res = self._sum(code, from_date, to_date)
+        return res and res[1] or 0.0
+
+
+class Payslips(BrowsableObject):
+    """a class that will be used into the python code, mainly for
+    usability purposes"""
+
+    def sum(self, code, from_date, to_date=None):
+        if to_date is None:
+            to_date = fields.Date.today()
+        self.env.cr.execute(
+            """SELECT sum(case when hp.credit_note = False then
+            (pl.total) else (-pl.total) end)
+                    FROM hr_payslip as hp, hr_payslip_line as pl
+                    WHERE hp.employee_id = %s AND hp.state = 'done'
+                    AND hp.date_from >= %s AND hp.date_to <= %s AND
+                     hp.id = pl.slip_id AND pl.code = %s""",
+            (self.employee_id, from_date, to_date, code),
+        )
+        res = self.env.cr.fetchone()
+        return res and res[0] or 0.0
+
+    def rule_parameter(self, code):
+        return self.env["hr.rule.parameter"]._get_parameter_from_code(
+            code, self.dict.date_to
+        )

--- a/payroll/models/hr_contract.py
+++ b/payroll/models/hr_contract.py
@@ -36,27 +36,10 @@ class HrContract(models.Model):
         """
         @return: the structures linked to the given contracts, ordered by
                  hierachy (parent=False first, then first level children and
-                 so on) and without duplicata
+                 so on) and without duplicates
         """
         structures = self.mapped("struct_id")
         if not structures:
             return []
         # YTI TODO return browse records
         return list(set(structures._get_parent_structure().ids))
-
-    def get_attribute(self, code, attribute):
-        return self.env["hr.contract.advantage.template"].search(
-            [("code", "=", code)], limit=1
-        )[attribute]
-
-    def set_attribute_value(self, code, active):
-        for contract in self:
-            if active:
-                value = (
-                    self.env["hr.contract.advantage.template"]
-                    .search([("code", "=", code)], limit=1)
-                    .default_value
-                )
-                contract[code] = value
-            else:
-                contract[code] = 0.0

--- a/payroll/models/hr_payslip.py
+++ b/payroll/models/hr_payslip.py
@@ -523,8 +523,8 @@ class HrPayslip(models.Model):
             "total": rule_total,
         }
         # sum the amount for its salary category
-        localdict = rule.category_id._sum_salary_rule_category(
-            localdict, rule_total - previous_amount
+        localdict = self._sum_salary_rule_category(
+            localdict, rule.category_id, rule_total - previous_amount
         )
         # create/overwrite the rule in the temporary results
         key = rule.code + "-" + str(localdict["contract"].id)
@@ -651,6 +651,17 @@ class HrPayslip(models.Model):
             }
         )
         return res
+
+    def _sum_salary_rule_category(self, localdict, category, amount):
+        self.ensure_one()
+        if category.parent_id:
+            localdict = self._sum_salary_rule_category(
+                localdict, category.parent_id, amount
+            )
+        localdict["categories"].dict[category.code] = (
+            localdict["categories"].dict.get(category.code, 0) + amount
+        )
+        return localdict
 
     def _get_employee_contracts(self):
         return self.env["hr.contract"].browse(

--- a/payroll/models/hr_payslip.py
+++ b/payroll/models/hr_payslip.py
@@ -512,12 +512,9 @@ class HrPayslip(models.Model):
         # set/overwrite the amount computed for this rule in the localdict
         localdict[rule.code] = rule_total
         localdict["rules"].dict[rule.code] = rule
-        localdict["result_rules"].dict[rule.code] = {
-            "quantity": qty,
-            "rate": rate,
-            "amount": amount,
-            "total": rule_total,
-        }
+        localdict["result_rules"].dict[rule.code] = BaseBrowsableObject(
+            {"quantity": qty, "rate": rate, "amount": amount, "total": rule_total}
+        )
         # sum the amount for its salary category
         localdict = self._sum_salary_rule_category(
             localdict, rule.category_id, rule_total - previous_amount

--- a/payroll/models/hr_payslip.py
+++ b/payroll/models/hr_payslip.py
@@ -477,20 +477,16 @@ class HrPayslip(models.Model):
             line.code: line for line in self.input_line_ids if line.code
         }
         localdict = {
-            **{
-                "payslip": Payslips(self.employee_id.id, self, self.env),
-                "worked_days": WorkedDays(
-                    self.employee_id.id, worked_days_dict, self.env
-                ),
-                "inputs": InputLine(self.employee_id.id, input_lines_dict, self.env),
-                "payroll": BrowsableObject(
-                    self.employee_id.id, self.get_payroll_dict(contracts), self.env
-                ),
-                "current_contract": BrowsableObject(self.employee_id.id, {}, self.env),
-                "categories": BrowsableObject(self.employee_id.id, {}, self.env),
-                "rules": BrowsableObject(self.employee_id.id, {}, self.env),
-                "result_rules": BrowsableObject(self.employee_id.id, {}, self.env),
-            },
+            "payslip": Payslips(self.employee_id.id, self, self.env),
+            "worked_days": WorkedDays(self.employee_id.id, worked_days_dict, self.env),
+            "inputs": InputLine(self.employee_id.id, input_lines_dict, self.env),
+            "payroll": BrowsableObject(
+                self.employee_id.id, self.get_payroll_dict(contracts), self.env
+            ),
+            "current_contract": BrowsableObject(self.employee_id.id, {}, self.env),
+            "categories": BrowsableObject(self.employee_id.id, {}, self.env),
+            "rules": BrowsableObject(self.employee_id.id, {}, self.env),
+            "result_rules": BrowsableObject(self.employee_id.id, {}, self.env),
         }
         return localdict
 

--- a/payroll/models/hr_salary_rule.py
+++ b/payroll/models/hr_salary_rule.py
@@ -79,10 +79,11 @@ class HrSalaryRule(models.Model):
             # inputs: object containing the computed inputs
             # payroll: object containing miscellaneous values related to payroll
             # current_contract: object with values calculated from the current contract
+            # result_rules: object with a dict of qty, rate, amount an total of calculated rules
 
             # Available compute variables:
             #-------------------------------
-            result: returned value have to be set in the variable 'result'
+            # result: returned value have to be set in the variable 'result'
 
             # Example:
             #-------------------------------
@@ -131,13 +132,14 @@ class HrSalaryRule(models.Model):
             # inputs: object containing the computed inputs.
             # payroll: object containing miscellaneous values related to payroll
             # current_contract: object with values calculated from the current contract
+            # result_rules: object with a dict of qty, rate, amount an total of calculated rules
 
             # Available compute variables:
             #-------------------------------
-            result: returned value have to be set in the variable 'result'
-            result_rate: the rate that will be applied to "result".
-            result_qty: the quantity of units that will be multiplied to "result".
-            result_name: if this variable is computed, it will contain the name of the line.
+            # result: returned value have to be set in the variable 'result'
+            # result_rate: the rate that will be applied to "result".
+            # result_qty: the quantity of units that will be multiplied to "result".
+            # result_name: if this variable is computed, it will contain the name of the line.
 
             # Example:
             #-------------------------------

--- a/payroll/models/hr_salary_rule_category.py
+++ b/payroll/models/hr_salary_rule_category.py
@@ -26,15 +26,6 @@ class HrSalaryRuleCategory(models.Model):
         default=lambda self: self.env.company,
     )
 
-    def _sum_salary_rule_category(self, localdict, amount):
-        self.ensure_one()
-        if self.parent_id:
-            localdict = self.parent_id._sum_salary_rule_category(localdict, amount)
-        localdict["categories"].dict[self.code] = (
-            localdict["categories"].dict.get(self.code, 0) + amount
-        )
-        return localdict
-
     @api.constrains("parent_id")
     def _check_parent_id(self):
         if not self._check_recursion():

--- a/payroll/models/hr_salary_rule_category.py
+++ b/payroll/models/hr_salary_rule_category.py
@@ -26,6 +26,15 @@ class HrSalaryRuleCategory(models.Model):
         default=lambda self: self.env.company,
     )
 
+    def _sum_salary_rule_category(self, localdict, amount):
+        self.ensure_one()
+        if self.parent_id:
+            localdict = self.parent_id._sum_salary_rule_category(localdict, amount)
+        localdict["categories"].dict[self.code] = (
+            localdict["categories"].dict.get(self.code, 0) + amount
+        )
+        return localdict
+
     @api.constrains("parent_id")
     def _check_parent_id(self):
         if not self._check_recursion():

--- a/payroll/readme/CONTRIBUTORS.rst
+++ b/payroll/readme/CONTRIBUTORS.rst
@@ -1,3 +1,5 @@
 * Odoo SA <info@odoo.com>
 * David James <david@djdc.net.au>
 * Hilar AK <hilarak@gmail.com>
+* Nimarosa (Nicolas Rodriguez) <nicolarsande@gmail.com>
+* Henrik Norlin (@appstogrow)

--- a/payroll/views/hr_payslip_views.xml
+++ b/payroll/views/hr_payslip_views.xml
@@ -186,10 +186,7 @@
                                 <tree string="Worked Days" editable="bottom">
                                     <field name="name" />
                                     <field name="code" />
-                                    <field
-                                        name="number_of_days"
-                                        sum="Total Working Days"
-                                    />
+                                    <field name="number_of_days" />
                                     <field name="number_of_hours" />
                                     <field
                                         name="contract_id"

--- a/payroll/views/hr_payslip_views.xml
+++ b/payroll/views/hr_payslip_views.xml
@@ -5,7 +5,6 @@
         <field name="model">hr.payslip</field>
         <field name="arch" type="xml">
             <tree
-                decoration-info="state in ('confirm','hr_check','accont_check')"
                 decoration-muted="state == 'cancel'"
                 string="Payslips"
                 multi_edit="1"
@@ -20,7 +19,8 @@
                 <field
                     name="state"
                     decoration-success="state == 'done'"
-                    decoration-info="state == 'draft' or state == 'verify'"
+                    decoration-warning="state == 'verify'"
+                    decoration-info="state == 'draft'"
                     decoration-danger="state == 'cancel'"
                     widget="badge"
                     optional="show"
@@ -83,39 +83,39 @@
                         string="Confirm"
                         name="action_payslip_done"
                         type="object"
-                        states="draft"
+                        states="verify"
                         class="oe_highlight"
                     />
                     <button
                         string="Refund"
                         name="refund_sheet"
-                        states="confirm,done"
+                        states="done"
                         type='object'
-                    />
-                    <button
-                        string="Set to Draft"
-                        name="action_payslip_draft"
-                        type="object"
-                        states="cancel"
                     />
                     <button
                         string="Compute Sheet"
                         name="compute_sheet"
                         type="object"
-                        states="draft"
+                        states="draft,verify"
                         class="oe_highlight"
                     />
                     <button
-                        string="Refetch Payslip Data"
-                        name="onchange_employee"
+                        string="Set to Draft"
+                        name="action_payslip_draft"
                         type="object"
-                        states="draft"
+                        states="cancel,verify"
                     />
                     <button
                         string="Cancel Payslip"
                         name="action_payslip_cancel"
                         type="object"
-                        states="draft,hr_check,confirm,verify"
+                        states="draft,confirm,verify"
+                    />
+                    <button
+                        string="Refetch Payslip Data"
+                        name="onchange_employee"
+                        type="object"
+                        states="draft,verify"
                     />
                     <field
                         name="state"
@@ -134,7 +134,7 @@
                             <field
                                 name="payslip_count"
                                 widget="statinfo"
-                                string="Payslip"
+                                string="Payslip Lines"
                                 help="Payslip Computation Details"
                             />
                         </button>
@@ -174,6 +174,10 @@
                         />
                         <field name="name" />
                         <field name="credit_note" />
+                        <field
+                            name="compute_date"
+                            attrs="{'invisible':[('compute_date','==',False)]}"
+                        />
                     </group>
                     <notebook>
                         <page name="input" string="Worked Days &amp; Inputs">
@@ -330,17 +334,24 @@
         <field name="model">hr.payslip</field>
         <field name="arch" type="xml">
             <search string="Search Payslips">
+                <field name="employee_id" />
                 <field
                     name="name"
                     string="Payslips"
                     filter_domain="['|',('name','ilike',self),('number','ilike',self)]"
                 />
                 <field name="date_from" />
+                <field name="contract_id" />
+                <field name="payslip_run_id" />
                 <filter
                     string="Draft"
                     name="draft"
-                    domain="[('state','=','draft')]"
-                    help="Draft Slip"
+                    domain="[('state', '=', 'draft')]"
+                />
+                <filter
+                    string="Pending Review"
+                    name="verify"
+                    domain="[('state', '=', 'verify')]"
                 />
                 <filter
                     string="Done"
@@ -348,8 +359,20 @@
                     domain="[('state','=','done')]"
                     help="Done Slip"
                 />
-                <field name="employee_id" />
-                <field name="payslip_run_id" />
+                <separator />
+                <filter
+                    string="Date"
+                    name="date_filter"
+                    date="date_to"
+                    default_period="last_month"
+                />
+                <separator />
+                <filter
+                    string="Refunded"
+                    name="credit_note"
+                    domain="[('credit_note', '=', True)]"
+                />
+                <separator />
                 <group expand="0" string="Group By">
                     <filter
                         string="Employees"

--- a/payroll/views/hr_salary_rule_views.xml
+++ b/payroll/views/hr_salary_rule_views.xml
@@ -131,7 +131,7 @@
                                         attrs="{'invisible':[('condition_select','!=','range')], 'required':[('condition_select','=','range')]}"
                                     />
                                 </div>
-                                <separator colspan="4" string="Company Contribution" />
+                                <separator string="Company Contribution" />
                                 <field name="register_id" />
                             </group>
                             <group string="Computation" name="computation">


### PR DESCRIPTION
Hello, this is the first refactoring PR of a set of refactorings i will be submitting to the module. 

I will do it in separate PRs to make them more easy to test, review and merge, and also to separate concerns. 

This PR, introduces the following changes: 

1. Refactoring of functions _get_payslip_lines and _get_localdict that are the main functions involved in payslip calculation. With this changes, the behavior is the same, but separating of concerns and refactoring in more short functions, give us the ability to inherit the functions in any external module in a easy and straightforward way. We now have _compute_payslip_line new function, that is used for calculating ONE line, so if we need to make changes inside the lines loop we can do it in this function.

2. Change in functions returns: Now you will note that the functions in general return localdict every time. This is useful because if we can edit localdict we can create any number of functions inheriting the main one and just change the localdict to get the data in easily. The _get_payslip_lines function now returns localdict, lines_dict meaning lines_dict the original "result_dict". In the prior implementation, since the function only returns result_dict, there was no easy way to inherit the function and change something that is saved inside localdict. Like i said, the behaviour of the calculation is the same but we now have more useful return values. 

3. Changes in _get_baselocaldict function, now this function creates the baselocaldict entirely. Previously part of the localdict was created in this function and part was hardcoded in the _get_payslip_lines function. Now we have this function complete and here we set the defaults and different objects for the localdict. 

4. I moved BaseBrowsableObject and its childs to a new file, so we reduce the length of the payslip file and also have a separate file to edit this local classes. 

5. I removed advantage_templates unused functions that were in hr_contract, since this functionality was moved to a new module. #45 

6. Now the function that sum the categories, is in the hr_salary_rule_category file, this means that we can inherit it and change it if we need in an external module. Also this is an example of the implementation of returning localdict, note the function takes the localdict as param, make the sum, and return localdict, so parent function can continue the loop. 

7. Introducing new field: "compute_date", which is a date field that will be automatically set when the payslip is computed, this way we can keep track of the last computed date. This is useful for cases when the user don't know if the computation saved is the last one and also for keeping a track of every computation. 

8. States: Now we are using the "verify" state, that in this module implementation was unused. I checked how the enterprise version deals with states and they use the "verify" state to be automatically set when the payslip is computed. This way, when you compute the payslip the state is changed to "verify" which indicates that the payslip has been computed and is waiting for the user to check it and confirm it. When the state is "verify" you can still compute the payslip again, the only difference is that when the state is not "draft" all fields in the payslip become not editable ones: So this is useful when you have different roles doing payroll. An HR user can compute the payslips and then he can not modify them (since the become "verify" state) and has to wait for the HR Manager to approve them. Anyway if the user want to change any date in the payslip he can just press "return to draft" and then compute again. 
I think this makes a lot of sense. Maybe we have to work in permissions groups to allow/disallow return to draft function for different roles. But now, we are using all the states defined in payslip, since before we only use draft, and confirm ones.

9. Finally we have a lot of tweaks in views, removal of unused or deprecated view functionalities and the addition of a lot of filters to some models. Payroll module has outdated views so i think we can even improve it more like it was done in previous PRs. But here we only added/improve what is related to this PR. Feel free to suggest changes because views are very important in this module and improve them is a priority.

*Important note:* 
While refactoring the files i noted that the feature introduced in #43 was a very useful one for external modules. More than I noticed when it was merged. I think we have to make more documentation about the new objects present in localdict "payroll" and "current_contract" since they allow to inject values directly to the localdict without having to inherit any other function. 

Now this PR allows more easy inheriting of module functions but i think for external modules like the one in #51 by @appstogrow this objects are the best approach to inject new values to localdict. We should use them every time we can, because that way we don't interact with payroll module functions and makes a more clear approach. Henrik, i think you can study this functionality but i think you can use this approach in your PR to inject the localdict values you need in your new module. Please check it. Anyways now you can inherit the main functions without problem but like i said, i think this is more useful approach to use. 

For now, this is the first PR of a series of refactoring ones. Please check and i wait for your comments/suggestions. 
Regards. 

