### PR TITLE
[14.0][IMP] payroll: refactor many methods to work on recordsets. No functional changes.

### DIFF
--- a/payroll/models/hr_payslip.py
+++ b/payroll/models/hr_payslip.py
@@ -683,11 +683,12 @@ class HrPayslip(models.Model):
         return localdict
 
     def _get_employee_contracts(self):
-        return self.env["hr.contract"].browse(
-            self.employee_id._get_contracts(
-                date_from=self.date_from, date_to=self.date_to
-            ).ids
-        )
+        contracts = self.env["hr.contract"]
+        for payslip in self:
+            contracts |= payslip.employee_id._get_contracts(
+                date_from=payslip.date_from, date_to=payslip.date_to
+            )
+        return contracts
 
     @api.onchange("struct_id")
     def onchange_struct_id(self):

--- a/payroll/models/hr_payslip.py
+++ b/payroll/models/hr_payslip.py
@@ -697,16 +697,17 @@ class HrPayslip(models.Model):
 
     @api.onchange("struct_id")
     def onchange_struct_id(self):
-        if not self.struct_id:
-            self.input_line_ids.unlink()
-            return
-        input_lines = self.input_line_ids.browse([])
-        input_line_ids = self.get_inputs(
-            self._get_employee_contracts(), self.date_from, self.date_to
-        )
-        for r in input_line_ids:
-            input_lines += input_lines.new(r)
-        self.input_line_ids = input_lines
+        for payslip in self:
+            if not payslip.struct_id:
+                payslip.input_line_ids.unlink()
+                return
+            input_lines = payslip.input_line_ids.browse([])
+            input_line_ids = payslip.get_inputs(
+                payslip._get_employee_contracts(), payslip.date_from, payslip.date_to
+            )
+            for r in input_line_ids:
+                input_lines += input_lines.new(r)
+            payslip.input_line_ids = input_lines
 
     @api.onchange("date_from", "date_to")
     def onchange_dates(self):

--- a/payroll/tests/test_payslip_flow.py
+++ b/payroll/tests/test_payslip_flow.py
@@ -364,3 +364,38 @@ class TestPayslipFlow(TestPayslipBase):
             len(developer_rules | sales_rules),
             "There are no duplicates in returned rules",
         )
+
+    def test_get_payslip_line_singleton(self):
+        self.apply_contract_cron()
+        payslip = self.Payslip.create({"employee_id": self.sally.id})
+        payslip.onchange_employee()
+
+        line_key = f"BASIC-{self.sally.contract_id.id}"
+        lines_dict = payslip.get_lines_dict()
+        self.assertIn(
+            line_key,
+            lines_dict.keys(),
+            "A line exists for the BASIC rule in the salary structure",
+        )
+
+    def test_get_payslip_line_multiple(self):
+
+        self.apply_contract_cron()
+        payslips = self.Payslip.create(
+            [
+                {"employee_id": self.richard_emp.id},
+                {"employee_id": self.sally.id},
+            ]
+        )
+        payslips[0].onchange_employee()
+        payslips[1].onchange_employee()
+
+        sally_key = f"BASIC-{self.sally.contract_id.id}"
+        richard_key = f"BASIC-{self.richard_emp.contract_id.id}"
+        lines_dict = payslips.get_lines_dict()
+        self.assertIn(
+            sally_key, lines_dict.keys(), "A line was created for Sally's contract"
+        )
+        self.assertIn(
+            richard_key, lines_dict.keys(), "A line was created for Richard's contract"
+        )

--- a/payroll/tests/test_payslip_flow.py
+++ b/payroll/tests/test_payslip_flow.py
@@ -1,6 +1,5 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo.fields import Date
 from odoo.tests import Form
 from odoo.tools import test_reports
 
@@ -188,22 +187,6 @@ class TestPayslipFlow(TestPayslipBase):
 
     def test_compute_multiple_payslips(self):
 
-        self.sally = self.env["hr.employee"].create(
-            {
-                "name": "Sally",
-                "department_id": self.ref("hr.dep_rd"),
-            }
-        )
-        self.env["hr.contract"].create(
-            {
-                "date_start": Date.today(),
-                "name": "Contract for Sally",
-                "wage": 5000.0,
-                "employee_id": self.sally.id,
-                "struct_id": self.developer_pay_structure.id,
-                "kanban_state": "done",
-            }
-        )
         self.apply_contract_cron()
         payslips = self.Payslip.create(
             [


### PR DESCRIPTION
The payroll code has many vestiges of the pre- recordset API lying around. Many functions require you to pass in a payslip_id or contracts, etc when they can just access it from the current record. This is inefficient and can also lead to bugs (like the one fixed in #68). So, I took a swing at correcting many of those places.

The refactored methods are:
_get_employee_contracts()
_get_salary_rules()
onchange_struct_id()
onchange_dates()
onchange_employee()

I also refactored the functionality in _get_payslip_lines(). However, since we can't change its signature at this late date I put the refactored code in a new method: get_lines_dict() and made _get_payslip_lines() call it, instead. To make sure people start using the new method I put a deprecation warning whenever _get_payslip_lines() is called.

If the diff is too big to read at once try looking at the diffs for the individual commits. That should make it easier to digest. As mentioned in the title: There should be no functional changes introduced.