### PR TITLE
[14.0] [FIX] payroll: Fix get_lines_dict() - assignation of dict 

### DIFF
--- a/payroll/models/hr_payslip.py
+++ b/payroll/models/hr_payslip.py
@@ -605,12 +605,12 @@ class HrPayslip(models.Model):
                         localdict, _dict = payslip._compute_payslip_line(
                             rule, localdict, lines_dict
                         )
+                        lines_dict.update(_dict)
                     else:
                         # blacklist this rule and its children
                         blacklist += [
                             id for id, seq in rule._recursive_search_of_rules()
                         ]
-                    lines_dict.update(_dict)
                 # call localdict_hook
                 localdict = payslip.localdict_hook(localdict)
                 # reset "current_contract" dict


### PR DESCRIPTION
Hello, this is a fast-merge fix for the function  get_lines_dict()

Before this change, the bug was that `lines_dict.update(_dict)` was outside the if (true) condition, so if a rule gets blacklisted it was trying to update the _dict anyways. 

This don't produce an error in the most cases but when the first rule of the payslip is blacklisted we get:
`UnboundLocalError: local variable '_dict' referenced before assignment`

Then i realised that this bug was happening in each iteration. If the rule was blacklisted, the code was overriding the last rule values. In the usage it's not an error, but when you have the firsts rules of the payslip blacklisted then you get this error because _dict was not defined. 

I will fast-merge this since i need it in production. Leave this PR as history of the change. 

Regards. 