### PR TITLE
[14.0] [IMP] payroll: Views improvements and new functionality

### DIFF
--- a/payroll/models/hr_payslip.py
+++ b/payroll/models/hr_payslip.py
@@ -1,6 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import logging
+import math
 from datetime import date, datetime, time
 
 import babel
@@ -483,6 +484,11 @@ class HrPayslip(models.Model):
 
         return {}
 
+    def _get_tools_dict(self):
+        # _get_tools_dict() is intended to be inherited by other private modules
+        # to add tools or python libraries available in localdict
+        return {"math": math}  # "math" object is useful for doing calculations
+
     def _get_baselocaldict(self, contracts):
         self.ensure_one()
         worked_days_dict = {
@@ -502,6 +508,9 @@ class HrPayslip(models.Model):
             "categories": BrowsableObject(self.employee_id.id, {}, self.env),
             "rules": BrowsableObject(self.employee_id.id, {}, self.env),
             "result_rules": BrowsableObject(self.employee_id.id, {}, self.env),
+            "tools": BrowsableObject(
+                self.employee_id.id, self._get_tools_dict(), self.env
+            ),
         }
         return localdict
 

--- a/payroll/models/hr_salary_rule.py
+++ b/payroll/models/hr_salary_rule.py
@@ -66,20 +66,19 @@ class HrSalaryRule(models.Model):
         required=True,
         default="""
             # Available variables:
-            #----------------------
+            #-------------------------------
             # payslip: object containing the payslips
-            # payslip.rule_parameter(code): get the value for the rule parameter specified.
-            #   By default it gets the code for payslip date.
             # employee: hr.employee object
             # contract: hr.contract object
             # rules: object containing the rules code (previously computed)
             # categories: object containing the computed salary rule categories
             #    (sum of amount of all rules belonging to that category).
-            # worked_days: object containing the computed worked days
-            # inputs: object containing the computed inputs
+            # worked_days: object containing the computed worked days.
+            # inputs: object containing the computed inputs.
             # payroll: object containing miscellaneous values related to payroll
             # current_contract: object with values calculated from the current contract
             # result_rules: object with a dict of qty, rate, amount an total of calculated rules
+            # tools: object that contain libraries and tools that can be used in calculations
 
             # Available compute variables:
             #-------------------------------
@@ -87,7 +86,7 @@ class HrSalaryRule(models.Model):
 
             # Example:
             #-------------------------------
-            result = rules.NET > categories.NET * 0.10
+            # result = worked_days.WORK0 and worked_days.WORK0.number_of_days > 0
 
             """,
         help="Applied this rule for calculation if condition is true. You can "
@@ -133,6 +132,7 @@ class HrSalaryRule(models.Model):
             # payroll: object containing miscellaneous values related to payroll
             # current_contract: object with values calculated from the current contract
             # result_rules: object with a dict of qty, rate, amount an total of calculated rules
+            # tools: object that contain libraries and tools that can be used in calculations
 
             # Available compute variables:
             #-------------------------------
@@ -143,7 +143,7 @@ class HrSalaryRule(models.Model):
 
             # Example:
             #-------------------------------
-            result = contract.wage * 0.10
+            # result = contract.wage * 0.10
 
             """,
     )

--- a/payroll/models/hr_salary_rule_category.py
+++ b/payroll/models/hr_salary_rule_category.py
@@ -19,6 +19,9 @@ class HrSalaryRuleCategory(models.Model):
     children_ids = fields.One2many(
         "hr.salary.rule.category", "parent_id", string="Children"
     )
+    salary_rules_ids = fields.One2many(
+        "hr.salary.rule", "category_id", string="Salary Rule Categories"
+    )
     note = fields.Text(string="Description")
     company_id = fields.Many2one(
         "res.company",

--- a/payroll/views/hr_payslip_views.xml
+++ b/payroll/views/hr_payslip_views.xml
@@ -256,14 +256,15 @@
                             >
                                 <tree
                                     string="Salary Structure"
-                                    decoration-info="total == 0"
+                                    decoration-info="total == 0 and appears_on_payslip == True"
                                     decoration-bf="parent_rule_id == False"
                                     decoration-it="parent_rule_id != False"
-                                    decoration-muted="parent_rule_id != False"
+                                    decoration-muted="parent_rule_id != False or appears_on_payslip != True"
                                     create="false"
                                     delete="false"
                                 >
-                                    <field name="sequence" invisible="1" />
+                                    <field name="appears_on_payslip" invisible="1" />
+                                    <field name="sequence" optional="hide" />
                                     <field name="parent_line_id" invisible="1" />
                                     <field name="parent_rule_id" invisible="1" />
                                     <field name="code" readonly="1" />
@@ -295,6 +296,9 @@
                                     <field name="category_id" decoration-bf="1" />
                                     <field name="code" widget="badge" />
                                     <field name="name" />
+                                    <field name="quantity" />
+                                    <field name="rate" readonly="1" />
+                                    <field name="amount" />
                                     <field
                                         name="total"
                                         decoration-bf="1"

--- a/payroll/views/hr_salary_rule_category_views.xml
+++ b/payroll/views/hr_salary_rule_category_views.xml
@@ -5,14 +5,36 @@
         <field name="model">hr.salary.rule.category</field>
         <field name="arch" type="xml">
             <form string="Salary Categories">
-                <group col="4">
-                    <field name="name" />
-                    <field name="code" />
-                    <field name="parent_id" />
-                </group>
-                <group string="Notes">
-                    <field name="note" nolabel="1" />
-                </group>
+                <sheet>
+                    <label for="name" class="oe_edit_only" />
+                    <h1>
+                        <field name="name" />
+                    </h1>
+                    <group>
+                        <group>
+                            <field name="code" />
+                            <field name="parent_id" />
+                        </group>
+                    </group>
+                    <notebook>
+                        <page string="Salary Rules">
+                            <separator string="Asociated Salary Rules" />
+                            <field name="salary_rules_ids" nolabel="1" create="false">
+                                <tree>
+                                    <field name="code" decoration-bf="1" />
+                                    <field name="name" />
+                                </tree>
+                            </field>
+                        </page>
+                    </notebook>
+                    <group string="Notes">
+                        <field
+                            name="note"
+                            placeholder="Add your notes or category explanation here..."
+                            nolabel="1"
+                        />
+                    </group>
+                </sheet>
             </form>
         </field>
     </record>

--- a/payroll/views/hr_salary_rule_views.xml
+++ b/payroll/views/hr_salary_rule_views.xml
@@ -70,129 +70,254 @@
         <field name="model">hr.salary.rule</field>
         <field name="arch" type="xml">
             <form string="Salary Rules">
-                <label for="name" class="oe_edit_only" />
-                <h1>
-                    <field name="name" />
-                </h1>
-                <label for="category_id" class="oe_edit_only" />
-                <h2>
-                    <field name="category_id" />
-                </h2>
-                <group name="principal">
-                    <group>
-                        <field name="code" />
-                        <field name="sequence" />
-                        <field
-                            name="company_id"
-                            options="{'no_create': True}"
-                            groups="base.group_multi_company"
-                        />
-                    </group>
-                    <group>
-                        <field name="active" />
-                        <field name="appears_on_payslip" />
-                    </group>
-                </group>
-                <notebook>
-                    <page string="General">
+                <div
+                    class="alert alert-info oe_edit_only"
+                    role="alert"
+                    attrs="{'invisible':[('amount_select','!=','code')]}"
+                >
+            <p>
+                If you have doubts about coding salary rules, check the "Help" tab in this form.
+            </p>
+        </div>
+                <sheet>
+                    <label for="name" class="oe_edit_only" />
+                    <h1>
+                        <field name="name" />
+                    </h1>
+                    <label for="category_id" class="oe_edit_only" />
+                    <h2>
+                        <field name="category_id" />
+                    </h2>
+                    <group name="principal">
                         <group>
-                            <group string="Conditions" name="conditions">
-                                <field name="condition_select" />
-                                <field
-                                    name="condition_python"
-                                    attrs="{'invisible':[('condition_select','!=','python')], 'required': [('condition_select','=','python')]}"
-                                    colspan="4"
-                                    widget="ace"
-                                    options="{'mode': 'python'}"
-                                    id="condition_python"
-                                />
-                                <field
-                                    name="condition_range"
-                                    attrs="{'invisible':[('condition_select','!=','range')], 'required':[('condition_select','=','range')]}"
-                                />
-                                <label
-                                    string="Condition Range"
-                                    attrs="{'invisible':[('condition_select','!=','range')], 'required':[('condition_select','=','range')]}"
-                                    for="condition_range_min"
-                                />
-                                <div
-                                    attrs="{'invisible':[('condition_select','!=','range')], 'required':[('condition_select','=','range')]}"
-                                >
-                                    <strong>Between </strong>
-                                    <field
-                                        name="condition_range_min"
-                                        class="oe_inline"
-                                        attrs="{'invisible':[('condition_select','!=','range')], 'required':[('condition_select','=','range')]}"
-                                    />
-                                    <strong> and </strong>
-                                    <field
-                                        name="condition_range_max"
-                                        class="oe_inline"
-                                        attrs="{'invisible':[('condition_select','!=','range')], 'required':[('condition_select','=','range')]}"
-                                    />
-                                </div>
-                                <separator string="Company Contribution" />
-                                <field name="register_id" />
-                            </group>
-                            <group string="Computation" name="computation">
-                                <field name="amount_select" />
-                                <field
-                                    name="amount_percentage_base"
-                                    attrs="{'invisible':[('amount_select','!=','percentage')], 'required': [('amount_select','=','percentage')]}"
-                                />
-                                <field
-                                    name="quantity"
-                                    attrs="{'invisible':[('amount_select','=','code')], 'required':[('amount_select','!=','code')]}"
-                                />
-                                <field
-                                    name="amount_fix"
-                                    attrs="{'invisible':[('amount_select','!=','fix')], 'required':[('amount_select','=','fix')]}"
-                                />
-                                <field
-                                    colspan="4"
-                                    name="amount_python_compute"
-                                    attrs="{'invisible':[('amount_select','!=','code')], 'required':[('amount_select','=','code')]}"
-                                    widget="ace"
-                                    options="{'mode': 'python'}"
-                                    id="amount_python_compute"
-                                />
-                                <field
-                                    name="amount_percentage"
-                                    attrs="{'invisible':[('amount_select','!=','percentage')], 'required':[('amount_select','=','percentage')]}"
-                                />
-                            </group>
+                            <field name="code" />
+                            <field name="sequence" />
+                            <field name="register_id" />
+                            <field
+                                name="company_id"
+                                options="{'no_create': True}"
+                                groups="base.group_multi_company"
+                            />
+                        </group>
+                        <group>
+                            <field name="active" widget="boolean_toggle" />
+                            <field name="appears_on_payslip" widget="boolean_toggle" />
+                        </group>
+                    </group>
+                    <notebook>
+                        <page string="Rule Configuration">
                             <separator string="Notes" />
                             <field
                                 name="note"
                                 placeholder="Write salary rule notes or observations here..."
                             />
-                        </group>
-                    </page>
-                    <page name="rules" string="Child Rules">
-                        <div class="alert alert-info" role="alert">
-                            <p>
-                                Child rule functionality is useful when you need other rules to be computed before the parent one. <br
-                                />
-                                This means that all salary rules declared as childs (parent of one rule) will be added to the computation
-                                if its parent rule is included in the salary structure. So child rules will only be computed if it's parent is
-                                computed. <br />
-                                This functionality is useful for doing auxiliar calculations that are used as dependencies for the parent
-                                salary rule (e.x. rules required for complex tax computation that needs data from several modules).
-                            </p>
-                        </div>
-                        <field name="parent_rule_id" />
-                        <separator string="Children Definition" />
-                        <field name="child_ids" />
-                    </page>
-                    <page string="Inputs">
-                        <field name="input_ids" mode="tree">
-                            <tree string="Input Data" editable="bottom">
-                                <field name="code" />
-                                <field name="name" />
-                            </tree>
-                        </field>
-                    </page>
-                </notebook>
+                            <group>
+                                <group string="Conditions" name="conditions">
+                                    <field
+                                        name="condition_select"
+                                        widget="selection_badge"
+                                        decoration-info="1"
+                                        decoration-bf="1"
+                                        nolabel="1"
+                                    />
+                                    <field
+                                        name="condition_python"
+                                        attrs="{'invisible':[('condition_select','!=','python')], 'required': [('condition_select','=','python')]}"
+                                        colspan="4"
+                                        widget="ace"
+                                        options="{'mode': 'python'}"
+                                        id="condition_python"
+                                        nolabel="1"
+                                    />
+                                    <field
+                                        name="condition_range"
+                                        attrs="{'invisible':[('condition_select','!=','range')], 'required':[('condition_select','=','range')]}"
+                                    />
+                                    <label
+                                        string="Condition Range"
+                                        attrs="{'invisible':[('condition_select','!=','range')], 'required':[('condition_select','=','range')]}"
+                                        for="condition_range_min"
+                                    />
+                                    <div
+                                        attrs="{'invisible':[('condition_select','!=','range')], 'required':[('condition_select','=','range')]}"
+                                    >
+                                        <strong>Between </strong>
+                                        <field
+                                            name="condition_range_min"
+                                            class="oe_inline"
+                                            attrs="{'invisible':[('condition_select','!=','range')], 'required':[('condition_select','=','range')]}"
+                                        />
+                                        <strong> and </strong>
+                                        <field
+                                            name="condition_range_max"
+                                            class="oe_inline"
+                                            attrs="{'invisible':[('condition_select','!=','range')], 'required':[('condition_select','=','range')]}"
+                                        />
+                                    </div>
+                                </group>
+                                <group string="Computation" name="computation">
+                                    <field
+                                        name="amount_select"
+                                        widget="selection_badge"
+                                        decoration-info="1"
+                                        decoration-bf="1"
+                                        nolabel="1"
+                                    />
+                                    <field
+                                        name="amount_percentage_base"
+                                        attrs="{'invisible':[('amount_select','!=','percentage')], 'required': [('amount_select','=','percentage')]}"
+                                    />
+                                    <field
+                                        name="quantity"
+                                        attrs="{'invisible':[('amount_select','=','code')], 'required':[('amount_select','!=','code')]}"
+                                    />
+                                    <field
+                                        name="amount_fix"
+                                        attrs="{'invisible':[('amount_select','!=','fix')], 'required':[('amount_select','=','fix')]}"
+                                    />
+                                    <field
+                                        colspan="4"
+                                        name="amount_python_compute"
+                                        attrs="{'invisible':[('amount_select','!=','code')], 'required':[('amount_select','=','code')]}"
+                                        widget="ace"
+                                        options="{'mode': 'python'}"
+                                        id="amount_python_compute"
+                                        nolabel="1"
+                                    />
+                                    <field
+                                        name="amount_percentage"
+                                        attrs="{'invisible':[('amount_select','!=','percentage')], 'required':[('amount_select','=','percentage')]}"
+                                    />
+                                </group>
+                            </group>
+                        </page>
+                        <page name="rules" string="Child Rules">
+                            <div class="alert alert-info" role="alert">
+                                <p>
+                                    Child rule functionality is useful when you need other rules to be computed before the parent one. <br
+                                    />
+                                    This means that all salary rules declared as childs (parent of one rule) will be added to the computation
+                                    if its parent rule is included in the salary structure. So child rules will only be computed if it's parent is
+                                    computed. <br />
+                                    This functionality is useful for doing auxiliar calculations that are used as dependencies for the parent
+                                    salary rule (e.x. rules required for complex tax computation that needs data from several modules).
+                                </p>
+                            </div>
+                            <field name="parent_rule_id" />
+                            <separator string="Children Definition" />
+                            <field name="child_ids" />
+                        </page>
+                        <page name="inputs" string="Inputs">
+                            <field name="input_ids" mode="tree">
+                                <tree string="Input Data" editable="bottom">
+                                    <field name="code" />
+                                    <field name="name" />
+                                </tree>
+                            </field>
+                        </page>
+                        <page name="help" string="Help">
+                            <group>
+                                <div style="margin-top: 4px;">
+                                    <h3>Salary Rules formula definition (Python)</h3>
+                                    <p>
+                                        In python definition in salary rules, you can write any code like you will do
+                                        in python. Any methematical operation or python function is supported.
+                                    </p>
+                                    <p>
+                                        The following objects and variables are available to you to use it in salary rules calculations.
+                                    </p>
+                                    <ul>
+                                        <li>
+                                            <code
+                                            >payslip:</code> contains current payslip data
+                                        </li>
+                                        <li>
+                                            <code
+                                            >employee:</code> contains current employee data
+                                        </li>
+                                        <li>
+                                            <code
+                                            >contract:</code> contains current contract data
+                                        </li>
+                                        <li>
+                                            <code
+                                            >rules:</code> contains the rule code (previusly computed)
+                                        </li>
+                                        <li>
+                                            <code
+                                            >categories:</code> contains the sum of amount of all rules belonging to that category
+                                        </li>
+                                        <li>
+                                            <code
+                                            >worked_days:</code> contains the computed worked days data
+                                        </li>
+                                        <li>
+                                            <code
+                                            >inputs:</code> contains the computed input data
+                                        </li>
+                                        <li>
+                                            <code
+                                            >payroll:</code> contains miscellaneous values related to payroll
+                                        </li>
+                                        <li>
+                                            <code
+                                            >current_contract:</code> contains values related/calculated for current contract
+                                        </li>
+                                        <li>
+                                            <code
+                                            >result_rules:</code> contains the values of previusly computed lines (qty, rate, amount, total)
+                                        </li>
+                                        <li>
+                                            <code
+                                            >tools:</code> contains tools and libraries which help with mathematical operations
+                                        </li>
+                                    </ul>
+                                    <p>
+                                        The calculations should be performed using the objects and variables below.
+                                        Then, you have to use specific compute variables which will store the data
+                                        for salary rule computation.
+                                    </p>
+                                    <ul>
+                                        <li>
+                                            <code
+                                            >result:</code> the returned value should be in this variable. It matches with "amount" column.
+                                        </li>
+                                        <li>
+                                            <code
+                                            >result_rate:</code> the rate that should be applied to "result"
+                                        </li>
+                                        <li>
+                                            <code
+                                            >result_qty:</code> the quantity of units that will be multiplied to "result"
+                                        </li>
+                                        <li>
+                                            <code
+                                            >result_name:</code> overrides the current name of the rule and allows to make dynamic names
+                                        </li>
+                                    </ul>
+                                    <h3>Examples</h3>
+                                    <ul>
+                                        <li>
+                                            <code>result = contract.wage * 0.10</code>
+                                        </li>
+                                        <li>
+                                            <code>
+                                                result = contract.wage
+                                                result_qty = worked_days.WORK100.number_of_days
+                                            </code>
+                                        </li>
+                                        <li>
+                                            <code>
+                                                result = contract.wage
+                                                result_rate = 10.0
+                                            </code>
+                                        </li>
+                                    </ul>
+                                </div>
+                            </group>
+                        </page>
+                    </notebook>
+                </sheet>
             </form>
         </field>
     </record>

--- a/payroll_account/views/hr_payroll_account_views.xml
+++ b/payroll_account/views/hr_payroll_account_views.xml
@@ -18,7 +18,7 @@
         <field name="model">hr.salary.rule</field>
         <field name="inherit_id" ref="payroll.hr_salary_rule_view_form" />
         <field name="arch" type="xml">
-            <xpath expr="/form/notebook/page[@name='rules']" position="after">
+            <page name="inputs" position="after">
                 <page string="Accounting">
                     <group>
                         <group>
@@ -36,7 +36,7 @@
                         </group>
                     </group>
                 </page>
-            </xpath>
+            </page>
         </field>
     </record>
     <!-- Contract View -->


### PR DESCRIPTION
Hello, in this PR i made some views tweaks that i forgotten to do in previous ones, but the change that is interesting here is the new functionality that allows (in a very simple and straightforward way) to add and use python libraries inside salary rules. 

Basically we have a new method called _get_tools_dict() which can be inherited by any custom module and add any library or object to it. Then the library will be accessible inside salary rules by doing: 

result = tools.math

It's a very simple implementation so i think we can merge this fast. I also added the "math" library by default because it's useful for me in my projects and i think it will be useful to use functions like math.ceil or math.floor inside salary rules. 
If you want to add more libraries or objects, please suggest and we can add them in this PR.

With this change, the power of salary rules can be extended practically to any use case. 

Hope you like it! Regards. 
