### PR TITLE
[14.0] [FIX] payroll: remove total compute method in favour of decimal precision 

### DIFF
--- a/payroll/data/hr_payroll_data.xml
+++ b/payroll/data/hr_payroll_data.xml
@@ -6,6 +6,14 @@
             <field name="name">Payroll</field>
             <field name="digits">2</field>
         </record>
+        <record
+            forcecreate="True"
+            id="decimal_payroll_amount"
+            model="decimal.precision"
+        >
+            <field name="name">Payroll Amount</field>
+            <field name="digits">4</field>
+        </record>
         <record forcecreate="True" id="decimal_payroll_rate" model="decimal.precision">
             <field name="name">Payroll Rate</field>
             <field name="digits">4</field>

--- a/payroll/models/hr_payslip_line.py
+++ b/payroll/models/hr_payslip_line.py
@@ -32,11 +32,13 @@ class HrPayslipLine(models.Model):
         "hr.contract", string="Contract", required=True, index=True
     )
     rate = fields.Float(string="Rate (%)", digits="Payroll Rate", default=100.0)
-    amount = fields.Float(digits="Payroll")
+    amount = fields.Float(digits="Payroll Amount")
     quantity = fields.Float(digits="Payroll", default=1.0)
     total = fields.Float(
+        compute="_compute_total",
         string="Total",
         digits="Payroll",
+        store=True,
     )
     allow_edit_payslip_lines = fields.Boolean(
         "Allow editing", compute="_compute_allow_edit_payslip_lines"
@@ -68,6 +70,11 @@ class HrPayslipLine(models.Model):
                 )
             else:
                 line.parent_line_id = False
+
+    @api.depends("quantity", "amount", "rate")
+    def _compute_total(self):
+        for line in self:
+            line.total = float(line.quantity) * line.amount * line.rate / 100
 
     @api.model_create_multi
     def create(self, vals_list):

--- a/payroll/models/hr_payslip_line.py
+++ b/payroll/models/hr_payslip_line.py
@@ -35,10 +35,8 @@ class HrPayslipLine(models.Model):
     amount = fields.Float(digits="Payroll")
     quantity = fields.Float(digits="Payroll", default=1.0)
     total = fields.Float(
-        compute="_compute_total",
         string="Total",
         digits="Payroll",
-        store=True,
     )
     allow_edit_payslip_lines = fields.Boolean(
         "Allow editing", compute="_compute_allow_edit_payslip_lines"
@@ -70,11 +68,6 @@ class HrPayslipLine(models.Model):
                 )
             else:
                 line.parent_line_id = False
-
-    @api.depends("quantity", "amount", "rate")
-    def _compute_total(self):
-        for line in self:
-            line.total = float(line.quantity) * line.amount * line.rate / 100
 
     @api.model_create_multi
     def create(self, vals_list):


### PR DESCRIPTION
As we always as programmers know, floats are very problematic when we have to deal with precision calculations, also, odoo decimal precision rounding do this worse. 

In this PR I removed decimal precision from the "amount" field in payslip lines. This is motivated by the necessity of precise calculations in payslips. All other fields remains with precision rounding, including "total" computed field which is the field that is displayed in payslips in most of the cases. "Amount" field is used for calculations and in the most of the cases, correspond to the value in "result" variable in salary_rules. Having precision in this field give us unprecise calculations for rules since odoo applies the rounding and we end up with weird values in some cases. Consider this example for more clarification: 

Salary Rule: 
Suposs contract.amount = 104779 and qty = 21 days
```
result = contract.amount / worked_days.WORK100.number_of_days  # This give us the daily unitary amount of a fixed salary
result_qty = worked_Days.WORK100.number_of_days # We use as qty the number of days worked
```

In a case that the employee has worked full time without absences, we should get `total = contract.amount`
The problem is that odoo applies rounding on "amount" field so we end up with the following results: 

```
contract.amount = 104779
unitary_amount = 4989.48 (rounded by odoo decimal precision) 
tota = 4989.48 * 21 = 104779.08 ≠ 104779
```

So as you can see, decimal precision in amount field give us incorrect values even when the calculation is simple (104779 / 21 * 21 SHOULD BE EQUAL TO 104779 and not 104779.08) 

So i think a solution for this is to not round "amount" field which is often a calculated value which we need to continue calculating next salary rules. 

--------------------

The only problem with this change, is that now in the database the values will be stored as they are, giving us values like this: 
<img width="1071" alt="Screen Shot 2022-10-04 at 01 46 39" src="https://user-images.githubusercontent.com/12401188/193736451-9ce3f6a3-7f66-4153-aa52-1643aef00be4.png">

This values are not a problem for calculations since they give us more precision but they are ugly to see. On the other hand, the UI continue reflecting rounded values like here: 
<img width="1048" alt="Screen Shot 2022-10-04 at 01 47 32" src="https://user-images.githubusercontent.com/12401188/193736541-f5f5cc27-b92a-4f55-aaba-6ce9dc5ce7ba.png">

So from the user point of view, it means no change. The only thing we should take into account is:
If we are going to use this value in reports, maybe we should round it before using it. I couldn't find other problem with storing "amount" this way. If you find any, please suggest changes or another idea on how to mitigate this errors. 

I know that the rounding don't affect the "total" a lot, but in payroll in general, values have to be the more exact as possible since sometimes people receiving the payslips don't understand why the value don't show like it should to be. 

Feel free to make comments, suggestions or ideas about this. 
I keep posted. Regards. 




