### PR TITLE
[14.0] [ADD] payroll_hr_public_holidays module 

### DIFF
--- a/payroll_hr_public_holidays/__init__.py
+++ b/payroll_hr_public_holidays/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (C) 2021 Nimarosa (Nicolas Rodriguez) (<nicolasrsande@gmail.com>).
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from . import models

--- a/payroll_hr_public_holidays/__manifest__.py
+++ b/payroll_hr_public_holidays/__manifest__.py
@@ -1,0 +1,16 @@
+# Copyright (C) 2021 Nimarosa (Nicolas Rodriguez) (<nicolasrsande@gmail.com>).
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+{
+    "name": "Payroll Public Holidays",
+    "version": "14.0.1.0.0",
+    "category": "Human Resources",
+    "website": "https://github.com/OCA/payroll",
+    "summary": "Integration between payroll and hr_public_holidays",
+    "license": "AGPL-3",
+    "author": "Nimarosa, Odoo Community Association (OCA)",
+    "depends": ["payroll", "hr_holidays", "hr_holidays_public"],
+    "data": [],
+    "installable": True,
+    "maintainers": ["nimarosa"],
+}

--- a/payroll_hr_public_holidays/models/__init__.py
+++ b/payroll_hr_public_holidays/models/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (C) 2021 Nimarosa (Nicolas Rodriguez) (<nicolasrsande@gmail.com>).
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from . import hr_payslip

--- a/payroll_hr_public_holidays/models/hr_payslip.py
+++ b/payroll_hr_public_holidays/models/hr_payslip.py
@@ -1,7 +1,6 @@
 # Copyright (C) 2021 Nimarosa (Nicolas Rodriguez) (<nicolasrsande@gmail.com>).
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from datetime import datetime, time
 
 from odoo import _, api, models
 
@@ -15,28 +14,29 @@ class HrPayslip(models.Model):
         for contract in contracts.filtered(
             lambda contract: contract.resource_calendar_id
         ):
-            day_from = datetime.combine(date_from, time.min)
-            day_to = datetime.combine(date_to, time.max)
-            day_contract_start = datetime.combine(contract.date_start, time.min)
             # only use payslip day_from if it's greather than contract start date
-            if day_from < day_contract_start:
-                day_from = day_contract_start
+            if date_from < contract.date_start:
+                date_from = contract.date_start
             # == compute public holidays == #
-            pholidays = self._compute_public_holidays_days(contract, day_from, day_to)
+            pholidays = self._compute_public_holidays_days(contract, date_from, date_to)
             if pholidays["number_of_days"] > 0:
                 res.append(pholidays)
         return res
 
-    def _compute_public_holidays_days(self, contract, day_from, day_to):
+    def _compute_public_holidays_days(self, contract, date_from, date_to):
         # get public holidays list
         public_holidays = self.env["hr.holidays.public"].get_holidays_list(
-            year=day_from.year,
-            start_dt=day_from,
-            end_dt=day_to,
+            year=date_from.year,
+            start_dt=date_from,
+            end_dt=date_to,
             employee_id=contract.employee_id.id,
         )
         ph_days = len(public_holidays)
-        ph_hours = ph_days * contract.employee_id.resource_calendar_id.hours_per_day
+        ph_hours = (
+            ph_days * 8
+        )  # Use 8 as default value if employee has no resource_calendar
+        if contract.employee_id.resource_calendar_id:
+            ph_hours = ph_days * contract.employee_id.resource_calendar_id.hours_per_day
         return {
             "name": _("Public Holidays Leaves"),
             "sequence": 10,

--- a/payroll_hr_public_holidays/models/hr_payslip.py
+++ b/payroll_hr_public_holidays/models/hr_payslip.py
@@ -1,0 +1,47 @@
+# Copyright (C) 2021 Nimarosa (Nicolas Rodriguez) (<nicolasrsande@gmail.com>).
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from datetime import datetime, time
+
+from odoo import _, api, models
+
+
+class HrPayslip(models.Model):
+    _inherit = "hr.payslip"
+
+    @api.model
+    def get_worked_day_lines(self, contracts, date_from, date_to):
+        res = super().get_worked_day_lines(contracts, date_from, date_to)
+        for contract in contracts.filtered(
+            lambda contract: contract.resource_calendar_id
+        ):
+            day_from = datetime.combine(date_from, time.min)
+            day_to = datetime.combine(date_to, time.max)
+            day_contract_start = datetime.combine(contract.date_start, time.min)
+            # only use payslip day_from if it's greather than contract start date
+            if day_from < day_contract_start:
+                day_from = day_contract_start
+            # == compute public holidays == #
+            pholidays = self._compute_public_holidays_days(contract, day_from, day_to)
+            if pholidays["number_of_days"] > 0:
+                res.append(pholidays)
+        return res
+
+    def _compute_public_holidays_days(self, contract, day_from, day_to):
+        # get public holidays list
+        public_holidays = self.env["hr.holidays.public"].get_holidays_list(
+            year=day_from.year,
+            start_dt=day_from,
+            end_dt=day_to,
+            employee_id=contract.employee_id.id,
+        )
+        ph_days = len(public_holidays)
+        ph_hours = ph_days * contract.employee_id.resource_calendar_id.hours_per_day
+        return {
+            "name": _("Public Holidays Leaves"),
+            "sequence": 10,
+            "code": "PHOL",
+            "number_of_days": ph_days,
+            "number_of_hours": ph_hours,
+            "contract_id": contract.id,
+        }

--- a/payroll_hr_public_holidays/readme/CONTRIBUTORS.rst
+++ b/payroll_hr_public_holidays/readme/CONTRIBUTORS.rst
@@ -1,0 +1,1 @@
+* Nimarosa (Nicolas Rodriguez) <nicolarsande@gmail.com>

--- a/payroll_hr_public_holidays/readme/DESCRIPTION.rst
+++ b/payroll_hr_public_holidays/readme/DESCRIPTION.rst
@@ -1,0 +1,4 @@
+Allows to link hr_holidays_public module with payroll.
+
+With this module installed, public holidats will automatically be fetched and displayed in worked days table for payslip computation.
+This is useful to countries that need to make salary rules with public holidays data.

--- a/payroll_hr_public_holidays/readme/USAGE.rst
+++ b/payroll_hr_public_holidays/readme/USAGE.rst
@@ -1,0 +1,3 @@
+- Set public holidays in holidays module
+- Create a payslip
+- Public holidays will be fetched automatically to the worked days table

--- a/setup/payroll_hr_public_holidays/odoo/addons/payroll_hr_public_holidays
+++ b/setup/payroll_hr_public_holidays/odoo/addons/payroll_hr_public_holidays
@@ -1,0 +1,1 @@
+../../../../payroll_hr_public_holidays

--- a/setup/payroll_hr_public_holidays/setup.py
+++ b/setup/payroll_hr_public_holidays/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)


### PR DESCRIPTION
Hello friends, 

This time i bring a new module. It's a simple module that links hr_holidays_public (from OCA/hr-holidays repo) with payroll. Basically this creates a line for public holidays in worked days table in payslip form. 

This is useful because in some countries we need to have specific salary rules to pay public holidays or make complex calculations. As the public holidays are automatically deducted from WORK100 entry, it might be useful to have a linea with number of days and hours of public holidays. 

Hope you find it useful. 
Regards. 