### PR TITLE
[14.0] [FIX] payroll: Fix parent rules dependency

### DIFF
--- a/payroll/models/hr_salary_rule.py
+++ b/payroll/models/hr_salary_rule.py
@@ -265,6 +265,10 @@ Here is the error received:
         """
         self.ensure_one()
         method = "_satisfy_condition_{}".format(self.condition_select)
+        if self.parent_rule_id:
+            current_result = api.call_kw(self, method, [self.ids, localdict], {})
+            parent_result = self.parent_rule_id._satisfy_condition(localdict)
+            return current_result and parent_result
         return api.call_kw(self, method, [self.ids, localdict], {})
 
     def _satisfy_condition_none(self, localdict):


### PR DESCRIPTION
Hello, this fixes parent/child salary rules functionality for the case when the child rules have a sequence < parent rule sequence. 

To reproduce the current behavior you can create two rules and assign the one with the < sequence as child of the > sequence. You will see that even if the second rule is not computed and then the system blacklist the rule and his childs, the child rule was computed before this blacklisting so you end up with the child rule being computed even if it should be blacklisted. 

This fix checks on _satisfy_condition() if the rule has a parent one, and if it does, it checks for the parent one condition and then compares the two conditions, the child rule condition and the parent one, leaving us that the child rule will only be computed if it's parent satisfies the condition, if not, it will return condition False even if it's own condition returns True. 

This is also useful for having child rules and not having to assign them conditions, you can only trust that the system will only compute child rules if the parent one is True. If not, it will be dropped and then blacklisted. 

Will make a more tests of this before merge, but i wanted to open the PR for us to test too. 
Regards. 