### PR TITLE
[14.0][IMP] payroll: settings, code not required, payslip batch with company

### DIFF
--- a/payroll/models/hr_payroll_structure.py
+++ b/payroll/models/hr_payroll_structure.py
@@ -42,6 +42,20 @@ class HrPayrollStructure(models.Model):
         "rule_id",
         string="Salary Rules",
     )
+    require_code = fields.Boolean(
+        "Require code",
+        compute="_compute_require_code",
+        default=lambda self: self._compute_require_code(),
+    )
+
+    def _compute_require_code(self):
+        require = (
+            self.env["ir.config_parameter"]
+            .sudo()
+            .get_param("payroll.require_code_and_category")
+        )
+        self.require_code = require
+        return require
 
     @api.constrains("parent_id")
     def _check_parent_id(self):

--- a/payroll/models/hr_payroll_structure.py
+++ b/payroll/models/hr_payroll_structure.py
@@ -20,7 +20,7 @@ class HrPayrollStructure(models.Model):
         return self.env.ref("hr_payroll.structure_base", False)
 
     name = fields.Char(required=True)
-    code = fields.Char(string="Reference", required=False)
+    code = fields.Char(string="Reference")
     company_id = fields.Many2one(
         "res.company",
         string="Company",

--- a/payroll/models/hr_payroll_structure.py
+++ b/payroll/models/hr_payroll_structure.py
@@ -20,7 +20,7 @@ class HrPayrollStructure(models.Model):
         return self.env.ref("hr_payroll.structure_base", False)
 
     name = fields.Char(required=True)
-    code = fields.Char(string="Reference", required=True)
+    code = fields.Char(string="Reference", required=False)
     company_id = fields.Many2one(
         "res.company",
         string="Company",

--- a/payroll/models/hr_payslip.py
+++ b/payroll/models/hr_payslip.py
@@ -164,7 +164,9 @@ class HrPayslip(models.Model):
         compute="_compute_payslip_count", string="Payslip Computation Details"
     )
     hide_child_lines = fields.Boolean(string="Hide Child Lines", default=False)
-    hide_invisible_lines = fields.Boolean(string="Hide Invisible Lines", default=False)
+    hide_invisible_lines = fields.Boolean(
+        string="Show only lines that appear on payslip", default=False
+    )
     compute_date = fields.Date("Compute Date")
     refunded_id = fields.Many2one(
         "hr.payslip", string="Refunded Payslip", readonly=True

--- a/payroll/models/hr_payslip.py
+++ b/payroll/models/hr_payslip.py
@@ -174,11 +174,22 @@ class HrPayslip(models.Model):
         "hr.payslip", string="Refunded Payslip", readonly=True
     )
     allow_cancel_payslips = fields.Boolean(
-        "Allow Cancel Payslips", compute="_compute_allow_cancel_payslips"
+        "Allow Canceling Payslips", compute="_compute_allow_cancel_payslips"
     )
     prevent_compute_on_confirm = fields.Boolean(
         "Prevent Compute on Confirm", compute="_compute_prevent_compute_on_confirm"
     )
+    show_details_by_salary_rule_category = fields.Boolean(
+        "Show Details by Salary Rule Category",
+        compute="_compute_show_details_by_salary_rule_category",
+    )
+
+    def _compute_allow_cancel_payslips(self):
+        self.allow_cancel_payslips = (
+            self.env["ir.config_parameter"]
+            .sudo()
+            .get_param("payroll.allow_cancel_payslips")
+        )
 
     def _compute_prevent_compute_on_confirm(self):
         self.prevent_compute_on_confirm = (
@@ -187,11 +198,11 @@ class HrPayslip(models.Model):
             .get_param("payroll.prevent_compute_on_confirm")
         )
 
-    def _compute_allow_cancel_payslips(self):
-        self.allow_cancel_payslips = (
+    def _compute_show_details_by_salary_rule_category(self):
+        self.show_details_by_salary_rule_category = (
             self.env["ir.config_parameter"]
             .sudo()
-            .get_param("payroll.allow_cancel_payslips")
+            .get_param("payroll.show_details_by_salary_rule_category")
         )
 
     @api.depends("line_ids", "hide_child_lines")

--- a/payroll/models/hr_payslip.py
+++ b/payroll/models/hr_payslip.py
@@ -141,11 +141,6 @@ class HrPayslip(models.Model):
         tracking=True,
         states={"draft": [("readonly", False)]},
     )
-    details_by_salary_rule_category = fields.One2many(
-        "hr.payslip.line",
-        compute="_compute_details_by_salary_rule_category",
-        string="Details by Salary Rule Category",
-    )
     dynamic_filtered_payslip_lines = fields.One2many(
         "hr.payslip.line",
         compute="_compute_dynamic_filtered_payslip_lines",
@@ -179,10 +174,6 @@ class HrPayslip(models.Model):
     prevent_compute_on_confirm = fields.Boolean(
         "Prevent Compute on Confirm", compute="_compute_prevent_compute_on_confirm"
     )
-    show_details_by_salary_rule_category = fields.Boolean(
-        "Show Details by Salary Rule Category",
-        compute="_compute_show_details_by_salary_rule_category",
-    )
 
     def _compute_allow_cancel_payslips(self):
         self.allow_cancel_payslips = (
@@ -198,13 +189,6 @@ class HrPayslip(models.Model):
             .get_param("payroll.prevent_compute_on_confirm")
         )
 
-    def _compute_show_details_by_salary_rule_category(self):
-        self.show_details_by_salary_rule_category = (
-            self.env["ir.config_parameter"]
-            .sudo()
-            .get_param("payroll.show_details_by_salary_rule_category")
-        )
-
     @api.depends("line_ids", "hide_child_lines")
     def _compute_dynamic_filtered_payslip_lines(self):
         for payslip in self:
@@ -214,13 +198,6 @@ class HrPayslip(models.Model):
                 ).filtered(lambda line: not line.parent_rule_id)
             else:
                 payslip.dynamic_filtered_payslip_lines = payslip.line_ids
-
-    @api.depends("line_ids")
-    def _compute_details_by_salary_rule_category(self):
-        for payslip in self:
-            payslip.details_by_salary_rule_category = payslip.mapped(
-                "line_ids"
-            ).filtered(lambda line: line.category_id and line.appears_on_payslip)
 
     def _compute_payslip_count(self):
         for payslip in self:

--- a/payroll/models/hr_payslip.py
+++ b/payroll/models/hr_payslip.py
@@ -551,7 +551,7 @@ class HrPayslip(models.Model):
         previous_amount = rule.code in localdict and localdict[rule.code] or 0.0
         # compute the rule to get some values for the payslip line
         values = rule._compute_rule(localdict)
-        key = rule.code + "-" + str(localdict["contract"].id)
+        key = (rule.code or str(rule.id)) + "-" + str(localdict["contract"].id)
         return self._get_lines_dict(
             rule, localdict, lines_dict, key, values, previous_amount
         )

--- a/payroll/models/hr_payslip.py
+++ b/payroll/models/hr_payslip.py
@@ -542,7 +542,7 @@ class HrPayslip(models.Model):
         previous_amount = rule.code in localdict and localdict[rule.code] or 0.0
         # compute the rule to get some values for the payslip line
         values = rule._compute_rule(localdict)
-        key = (rule.code or str(rule.id)) + "-" + str(localdict["contract"].id)
+        key = (rule.code or "id" + str(rule.id)) + "-" + str(localdict["contract"].id)
         return self._get_lines_dict(
             rule, localdict, lines_dict, key, values, previous_amount
         )
@@ -553,9 +553,10 @@ class HrPayslip(models.Model):
         total = values["quantity"] * values["rate"] * values["amount"] / 100.0
         values["total"] = total
         # set/overwrite the amount computed for this rule in the localdict
-        localdict[rule.code] = total
-        localdict["rules"].dict[rule.code] = rule
-        localdict["result_rules"].dict[rule.code] = BaseBrowsableObject(values)
+        if rule.code:
+            localdict[rule.code] = total
+            localdict["rules"].dict[rule.code] = rule
+            localdict["result_rules"].dict[rule.code] = BaseBrowsableObject(values)
         # sum the amount for its salary category
         localdict = self._sum_salary_rule_category(
             localdict, rule.category_id, total - previous_amount
@@ -699,9 +700,10 @@ class HrPayslip(models.Model):
             localdict = self._sum_salary_rule_category(
                 localdict, category.parent_id, amount
             )
-        localdict["categories"].dict[category.code] = (
-            localdict["categories"].dict.get(category.code, 0) + amount
-        )
+        if category.code:
+            localdict["categories"].dict[category.code] = (
+                localdict["categories"].dict.get(category.code, 0) + amount
+            )
         return localdict
 
     def _get_employee_contracts(self):

--- a/payroll/models/hr_payslip_run.py
+++ b/payroll/models/hr_payslip_run.py
@@ -30,6 +30,13 @@ class HrPayslipRun(models.Model):
         tracking=1,
         default="draft",
     )
+    company_id = fields.Many2one(
+        "res.company",
+        string="Company",
+        required=True,
+        copy=False,
+        default=lambda self: self.env.company,
+    )
     date_start = fields.Date(
         string="Date From",
         required=True,

--- a/payroll/models/hr_salary_rule.py
+++ b/payroll/models/hr_salary_rule.py
@@ -12,7 +12,6 @@ class HrSalaryRule(models.Model):
 
     name = fields.Char(required=True, translate=True)
     code = fields.Char(
-        required=False,
         help="The code of salary rules can be used as reference in computation "
         "of other rules. In that case, it is case sensitive.",
     )
@@ -26,9 +25,7 @@ class HrSalaryRule(models.Model):
         "1€ per worked day can have its quantity defined in expression "
         "like worked_days.WORK100.number_of_days.",
     )
-    category_id = fields.Many2one(
-        "hr.salary.rule.category", string="Category", required=False
-    )
+    category_id = fields.Many2one("hr.salary.rule.category", string="Category")
     active = fields.Boolean(
         default=True,
         help="If the active field is set to false, it will allow you to hide"

--- a/payroll/models/hr_salary_rule.py
+++ b/payroll/models/hr_salary_rule.py
@@ -162,6 +162,11 @@ class HrSalaryRule(models.Model):
     )
     input_ids = fields.One2many("hr.rule.input", "input_id", string="Inputs", copy=True)
     note = fields.Text(string="Description")
+    require_code_and_category = fields.Boolean(
+        "Require code and category",
+        compute="_compute_require_code_and_category",
+        default=lambda self: self._compute_require_code_and_category(),
+    )
 
     @api.constrains("parent_rule_id")
     def _check_parent_rule_id(self):
@@ -186,6 +191,15 @@ class HrSalaryRule(models.Model):
         localdict["result_rate"] = 100
         localdict["result"] = None
         return localdict
+
+    def _compute_require_code_and_category(self):
+        require = (
+            self.env["ir.config_parameter"]
+            .sudo()
+            .get_param("payroll.require_code_and_category")
+        )
+        self.require_code_and_category = require
+        return require
 
     # TODO should add some checks on the type of result (should be float)
     def _compute_rule(self, localdict):

--- a/payroll/models/hr_salary_rule.py
+++ b/payroll/models/hr_salary_rule.py
@@ -12,7 +12,7 @@ class HrSalaryRule(models.Model):
 
     name = fields.Char(required=True, translate=True)
     code = fields.Char(
-        required=True,
+        required=False,
         help="The code of salary rules can be used as reference in computation "
         "of other rules. In that case, it is case sensitive.",
     )
@@ -27,7 +27,7 @@ class HrSalaryRule(models.Model):
         "like worked_days.WORK100.number_of_days.",
     )
     category_id = fields.Many2one(
-        "hr.salary.rule.category", string="Category", required=True
+        "hr.salary.rule.category", string="Category", required=False
     )
     active = fields.Boolean(
         default=True,

--- a/payroll/models/hr_salary_rule_category.py
+++ b/payroll/models/hr_salary_rule_category.py
@@ -9,7 +9,7 @@ class HrSalaryRuleCategory(models.Model):
     _description = "Salary Rule Category"
 
     name = fields.Char(required=True, translate=True)
-    code = fields.Char(required=False)
+    code = fields.Char()
     parent_id = fields.Many2one(
         "hr.salary.rule.category",
         string="Parent",

--- a/payroll/models/hr_salary_rule_category.py
+++ b/payroll/models/hr_salary_rule_category.py
@@ -9,7 +9,7 @@ class HrSalaryRuleCategory(models.Model):
     _description = "Salary Rule Category"
 
     name = fields.Char(required=True, translate=True)
-    code = fields.Char(required=True)
+    code = fields.Char(required=False)
     parent_id = fields.Many2one(
         "hr.salary.rule.category",
         string="Parent",

--- a/payroll/models/hr_salary_rule_category.py
+++ b/payroll/models/hr_salary_rule_category.py
@@ -28,6 +28,20 @@ class HrSalaryRuleCategory(models.Model):
         string="Company",
         default=lambda self: self.env.company,
     )
+    require_code = fields.Boolean(
+        "Require code",
+        compute="_compute_require_code",
+        default=lambda self: self._compute_require_code(),
+    )
+
+    def _compute_require_code(self):
+        require = (
+            self.env["ir.config_parameter"]
+            .sudo()
+            .get_param("payroll.require_code_and_category")
+        )
+        self.require_code = require
+        return require
 
     @api.constrains("parent_id")
     def _check_parent_id(self):

--- a/payroll/models/res_config_settings.py
+++ b/payroll/models/res_config_settings.py
@@ -31,7 +31,7 @@ class ResConfigSettings(models.TransientModel):
     )
     require_code_and_category = fields.Boolean(
         config_parameter="payroll.require_code_and_category",
-        string="Require code and category",
+        string="Require code/category on rules, categories and structures",
         help="Require rule.code, rule.category, category.code, structure.code",
         default=False,
     )

--- a/payroll/models/res_config_settings.py
+++ b/payroll/models/res_config_settings.py
@@ -29,9 +29,3 @@ class ResConfigSettings(models.TransientModel):
         help="Allow users to edit some payslip line fields manually",
         default=False,
     )
-    show_details_by_salary_rule_category = fields.Boolean(
-        config_parameter="payroll.show_details_by_salary_rule_category",
-        string="Show salary rules appearing on payslip",
-        help="Show Details by Salary Rule Category",
-        default=False,
-    )

--- a/payroll/models/res_config_settings.py
+++ b/payroll/models/res_config_settings.py
@@ -29,3 +29,9 @@ class ResConfigSettings(models.TransientModel):
         help="Allow users to edit some payslip line fields manually",
         default=False,
     )
+    require_code_and_category = fields.Boolean(
+        config_parameter="payroll.require_code_and_category",
+        string="Require code and category",
+        help="Require rule.code, rule.category, category.code, structure.code",
+        default=False,
+    )

--- a/payroll/models/res_config_settings.py
+++ b/payroll/models/res_config_settings.py
@@ -10,23 +10,28 @@ class ResConfigSettings(models.TransientModel):
     leaves_positive = fields.Boolean(
         config_parameter="payroll.leaves_positive",
         string="Leaves with positive values",
-        help="Values for leaves (days and hours fields) "
-        "should be positive instead of negative.",
+        help="In payslip worked days, leave days/hours have positive values",
     )
     allow_cancel_payslips = fields.Boolean(
         config_parameter="payroll.allow_cancel_payslips",
-        string="Allow cancel confirmed payslips",
-        help="If enabled, it allow the user to cancel confirmed payslips. Default: Not Enabled",
+        string="Allow canceling confirmed payslips",
+        help="Allow users to cancel confirmed payslips.",
     )
     prevent_compute_on_confirm = fields.Boolean(
         config_parameter="payroll.prevent_compute_on_confirm",
-        string="No compute on confirm",
-        help="If enabled, this setting will prevent the payslip to be re-computed on confirm.",
+        string="Confirm payslips without recomputing",
+        help="Prevent payslips from being recomputed when confirming them",
         default=True,
     )
     allow_edit_payslip_lines = fields.Boolean(
         config_parameter="payroll.allow_edit_payslip_lines",
-        string="Payslip lines editable",
-        help="Allow editing payslip lines manually in views and forms",
+        string="Allow editing payslip lines",
+        help="Allow users to edit some payslip line fields manually",
+        default=False,
+    )
+    show_details_by_salary_rule_category = fields.Boolean(
+        config_parameter="payroll.show_details_by_salary_rule_category",
+        string="Show salary rules appearing on payslip",
+        help="Show Details by Salary Rule Category",
         default=False,
     )

--- a/payroll/report/report_payslip_details.py
+++ b/payroll/report/report_payslip_details.py
@@ -107,9 +107,7 @@ class PayslipDetailsReport(models.AbstractModel):
             "docs": payslips,
             "data": data,
             "get_details_by_rule_category": self.get_details_by_rule_category(
-                payslips.mapped("details_by_salary_rule_category").filtered(
-                    lambda r: r.appears_on_payslip
-                )
+                payslips.mapped("line_ids").filtered(lambda r: r.appears_on_payslip)
             ),
             "get_lines_by_contribution_register": self.get_lines_by_contribution_register(  # noqa: disable=B950
                 payslips.mapped("line_ids").filtered(lambda r: r.appears_on_payslip)

--- a/payroll/tests/common.py
+++ b/payroll/tests/common.py
@@ -207,7 +207,7 @@ class TestPayslipBase(TransactionCase):
         )
 
         # I create a contract for "Richard"
-        self.Contract.create(
+        self.richard_contract = self.Contract.create(
             {
                 "date_start": Date.today(),
                 "name": "Contract for Richard",

--- a/payroll/tests/test_hr_salary_rule.py
+++ b/payroll/tests/test_hr_salary_rule.py
@@ -72,6 +72,7 @@ class TestSalaryRule(TestPayslipBase):
         self.assertEqual(line.amount, 0.0, "The amount is zero")
         self.assertEqual(line.rate, 0.0, "The rate is zero")
         self.assertEqual(line.quantity, 0.0, "The quantity is zero")
+        self.assertEqual(line.code, "TEST", "The code is 'TEST'")
 
     def test_python_code_result_not_set(self):
 

--- a/payroll/tests/test_hr_salary_rule.py
+++ b/payroll/tests/test_hr_salary_rule.py
@@ -139,3 +139,58 @@ class TestSalaryRule(TestPayslipBase):
         child_line = payslip.line_ids.filtered(lambda l: l.code == "CHILD_TEST")
         self.assertEqual(len(parent_line), 0, "No parent line found")
         self.assertEqual(len(child_line), 0, "No child line found")
+
+    def test_rule_and_category_with_and_without_code(self):
+        rule_test_code = self.SalaryRule.create(
+            {
+                "name": "rule test code",
+                "code": "rule_test_code",
+                "sequence": 100,
+                "amount_select": "code",
+                "amount_python_compute": "result = categories.BASIC + HRA",
+            }
+        )
+        category_without_code = self.SalaryRuleCateg.create({"name": "categ no code"})
+        rule_without_code = self.SalaryRule.create(
+            {
+                "name": "rule without code",
+                "category_id": category_without_code.id,
+                "sequence": 10,
+                "amount_select": "code",
+                "amount_python_compute": "result = 100",
+            }
+        )
+        rule_without_category = self.SalaryRule.create(
+            {
+                "name": "rule without category",
+                "sequence": 10,
+                "amount_select": "code",
+                "amount_python_compute": "result = 100",
+            }
+        )
+        structure = self.PayrollStructure.create(
+            {
+                "name": "test code and id",
+                "rule_ids": [
+                    (4, self.rule_basic.id),
+                    (4, self.rule_hra.id),
+                    (4, rule_test_code.id),
+                    (4, rule_without_code.id),
+                    (4, rule_without_category.id),
+                ],
+            }
+        )
+        payslip = self.Payslip.create(
+            {
+                "employee_id": self.richard_emp.id,
+                "contract_id": self.richard_contract.id,
+                "struct_id": structure.id,
+            }
+        )
+        payslip.compute_sheet()
+        line = payslip.line_ids.filtered(lambda l: l.code == "rule_test_code")
+        self.assertEqual(line.total, 7000, "5000 categories.BASIC + 2000 HRA = 7000")
+        line = payslip.line_ids.filtered(lambda l: l.name == "rule without code")
+        self.assertEqual(len(line), 1, "Line found: rule without code")
+        line = payslip.line_ids.filtered(lambda l: l.name == "rule without category")
+        self.assertEqual(len(line), 1, "Line found: rule without category")

--- a/payroll/views/hr_payroll_structure_views.xml
+++ b/payroll/views/hr_payroll_structure_views.xml
@@ -79,9 +79,13 @@
         <field name="model">hr.payroll.structure</field>
         <field name="arch" type="xml">
             <form string="Employee Function">
+                <field name="require_code" invisible="1" />
                 <group col="4">
                     <field name="name" />
-                    <field name="code" />
+                    <field
+                        name="code"
+                        attrs="{'required': [('require_code','=',True)]}"
+                    />
                     <field name="parent_id" />
                     <field
                         name="company_id"

--- a/payroll/views/hr_payslip_run_views.xml
+++ b/payroll/views/hr_payslip_run_views.xml
@@ -7,6 +7,7 @@
         <field name="arch" type="xml">
             <search string="Search Payslip Batches">
                 <field name="name" string="Payslip Batches" />
+                <field name="company_id" groups="base.group_multi_company" />
                 <field name="date_start" />
                 <field name="date_end" />
                 <filter
@@ -48,6 +49,11 @@
                     optional="show"
                 />
                 <field name="message_needaction" invisible="1" />
+                <field
+                    name="company_id"
+                    groups="base.group_multi_company"
+                    optional="show"
+                />
             </tree>
         </field>
     </record>
@@ -63,6 +69,10 @@
                                 <div class="col-6">
                                     <strong>
                                         <field name="name" />
+                                        <field
+                                            name="company_id"
+                                            groups="base.group_multi_company"
+                                        />
                                     </strong>
                                 </div>
                                 <div class="col-6">
@@ -141,6 +151,10 @@
                                     options="{'related_start_date': 'date_start'}"
                                 />
                             </div>
+                            <field
+                                name="company_id"
+                                groups="base.group_multi_company"
+                            />
                         </group>
                         <group name="other">
                             <field name="struct_id" />

--- a/payroll/views/hr_payslip_views.xml
+++ b/payroll/views/hr_payslip_views.xml
@@ -80,7 +80,6 @@
             <form string="Payslip">
                 <header>
                     <field name="allow_cancel_payslips" invisible="1" />
-                    <field name="show_details_by_salary_rule_category" invisible="1" />
                     <button
                         string="Confirm"
                         name="action_payslip_done"
@@ -285,31 +284,7 @@
                                         decoration-success="total > 0 and parent_rule_id == False"
                                         readonly="1"
                                     />
-                                </tree>
-                            </field>
-                        </page>
-                        <page
-                            name="details"
-                            string="Salary rules appearing on payslip"
-                            attrs="{'invisible': [('show_details_by_salary_rule_category', '=', False)]}"
-                        >
-                            <field name="details_by_salary_rule_category">
-                                <tree
-                                    string="Payslip Lines"
-                                    decoration-info="total == 0"
-                                >
-                                    <field name="category_id" decoration-bf="1" />
-                                    <field name="code" widget="badge" />
-                                    <field name="name" />
-                                    <field name="quantity" />
-                                    <field name="rate" readonly="1" />
-                                    <field name="amount" />
-                                    <field
-                                        name="total"
-                                        decoration-bf="1"
-                                        decoration-danger="0 > total"
-                                        decoration-success="total > 0"
-                                    />
+                                    <field name="appears_on_payslip" optional="hide" />
                                 </tree>
                             </field>
                         </page>

--- a/payroll/views/hr_payslip_views.xml
+++ b/payroll/views/hr_payslip_views.xml
@@ -80,6 +80,7 @@
             <form string="Payslip">
                 <header>
                     <field name="allow_cancel_payslips" invisible="1" />
+                    <field name="show_details_by_salary_rule_category" invisible="1" />
                     <button
                         string="Confirm"
                         name="action_payslip_done"
@@ -197,8 +198,8 @@
                                 <tree string="Worked Days" editable="bottom">
                                     <field name="name" />
                                     <field name="code" />
-                                    <field name="number_of_days" />
-                                    <field name="number_of_hours" />
+                                    <field name="number_of_days" string="Days" />
+                                    <field name="number_of_hours" string="Hours" />
                                     <field
                                         name="contract_id"
                                         domain="[('employee_id','=',parent.employee_id),('date_start','&lt;=',parent.date_to),'|',('date_end','&gt;=',parent.date_from),('date_end','=',False)]"
@@ -287,7 +288,11 @@
                                 </tree>
                             </field>
                         </page>
-                        <page name="details" string="Salary rules apearing on payslip">
+                        <page
+                            name="details"
+                            string="Salary rules appearing on payslip"
+                            attrs="{'invisible': [('show_details_by_salary_rule_category', '=', False)]}"
+                        >
                             <field name="details_by_salary_rule_category">
                                 <tree
                                     string="Payslip Lines"

--- a/payroll/views/hr_payslip_views.xml
+++ b/payroll/views/hr_payslip_views.xml
@@ -248,6 +248,10 @@
                                     name="hide_child_lines"
                                     widget="boolean_toggle"
                                 />
+                                <field
+                                    name="hide_invisible_lines"
+                                    widget="boolean_toggle"
+                                />
                             </group>
                             <field
                                 name="dynamic_filtered_payslip_lines"
@@ -284,7 +288,6 @@
                                         decoration-success="total > 0 and parent_rule_id == False"
                                         readonly="1"
                                     />
-                                    <field name="appears_on_payslip" optional="hide" />
                                 </tree>
                             </field>
                         </page>

--- a/payroll/views/hr_salary_rule_category_views.xml
+++ b/payroll/views/hr_salary_rule_category_views.xml
@@ -18,7 +18,7 @@
                     </group>
                     <notebook>
                         <page string="Salary Rules">
-                            <separator string="Asociated Salary Rules" />
+                            <separator string="Associated Salary Rules" />
                             <field name="salary_rules_ids" nolabel="1" create="false">
                                 <tree>
                                     <field name="code" decoration-bf="1" />

--- a/payroll/views/hr_salary_rule_category_views.xml
+++ b/payroll/views/hr_salary_rule_category_views.xml
@@ -5,6 +5,7 @@
         <field name="model">hr.salary.rule.category</field>
         <field name="arch" type="xml">
             <form string="Salary Categories">
+                <field name="require_code" invisible="1" />
                 <sheet>
                     <label for="name" class="oe_edit_only" />
                     <h1>
@@ -12,7 +13,10 @@
                     </h1>
                     <group>
                         <group>
-                            <field name="code" required="1" />
+                            <field
+                                name="code"
+                                attrs="{'required': [('require_code','=',True)]}"
+                            />
                             <field name="parent_id" />
                         </group>
                     </group>

--- a/payroll/views/hr_salary_rule_category_views.xml
+++ b/payroll/views/hr_salary_rule_category_views.xml
@@ -12,7 +12,7 @@
                     </h1>
                     <group>
                         <group>
-                            <field name="code" />
+                            <field name="code" required="1" />
                             <field name="parent_id" />
                         </group>
                     </group>

--- a/payroll/views/hr_salary_rule_views.xml
+++ b/payroll/views/hr_salary_rule_views.xml
@@ -70,6 +70,7 @@
         <field name="model">hr.salary.rule</field>
         <field name="arch" type="xml">
             <form string="Salary Rules">
+                <field name="require_code_and_category" invisible="1" />
                 <div
                     class="alert alert-info oe_edit_only"
                     role="alert"
@@ -86,11 +87,17 @@
                     </h1>
                     <label for="category_id" class="oe_edit_only" />
                     <h2>
-                        <field name="category_id" required="1" />
+                        <field
+                            name="category_id"
+                            attrs="{'required': [('require_code_and_category','=',True)]}"
+                        />
                     </h2>
                     <group name="principal">
                         <group>
-                            <field name="code" required="1" />
+                            <field
+                                name="code"
+                                attrs="{'required': [('require_code_and_category','=',True)]}"
+                            />
                             <field name="sequence" />
                             <field name="register_id" />
                             <field

--- a/payroll/views/hr_salary_rule_views.xml
+++ b/payroll/views/hr_salary_rule_views.xml
@@ -86,11 +86,11 @@
                     </h1>
                     <label for="category_id" class="oe_edit_only" />
                     <h2>
-                        <field name="category_id" />
+                        <field name="category_id" required="1" />
                     </h2>
                     <group name="principal">
                         <group>
-                            <field name="code" />
+                            <field name="code" required="1" />
                             <field name="sequence" />
                             <field name="register_id" />
                             <field

--- a/payroll/views/res_config_settings_views.xml
+++ b/payroll/views/res_config_settings_views.xml
@@ -103,23 +103,6 @@
                             </div>
                         </div>
                     </div>
-                    <h2>Features</h2>
-                    <div
-                        class="row mt16 o_settings_container"
-                        id="show_details_by_salary_rule_category"
-                    >
-                        <div class="col-lg-6 col-12 o_setting_box">
-                            <div class="o_setting_left_pane">
-                                <field name="show_details_by_salary_rule_category" />
-                            </div>
-                            <div class="o_setting_right_pane">
-                                <label for="show_details_by_salary_rule_category" />
-                                <div class="text-muted">
-                                    Show details by salary rule category
-                                </div>
-                            </div>
-                        </div>
-                    </div>
                 </div>
             </xpath>
         </field>

--- a/payroll/views/res_config_settings_views.xml
+++ b/payroll/views/res_config_settings_views.xml
@@ -36,13 +36,13 @@
                                     string="Payroll Entries"
                                 />
                                 <div class="text-muted">
-                                    Post payroll slips in accounting
+                                    Post payslips in accounting
                                 </div>
                             </div>
                         </div>
                     </div>
                     <h2>Calculation Settings</h2>
-                    <div class="row mt16 o_settings_container" id="worked_days">
+                    <div class="row mt16 o_settings_container" id="leaves_positive">
                         <div class="col-lg-6 col-12 o_setting_box">
                             <div class="o_setting_left_pane">
                                 <field name="leaves_positive" />
@@ -50,12 +50,15 @@
                             <div class="o_setting_right_pane">
                                 <label for="leaves_positive" />
                                 <div class="text-muted">
-                                    Display non-negative values for leaves in payslip worked days lines.
+                                    In payslip worked days, leave days/hours have positive values
                                 </div>
                             </div>
                         </div>
                     </div>
-                    <div class="row mt16 o_settings_container" id="cancel_payslips">
+                    <div
+                        class="row mt16 o_settings_container"
+                        id="allow_cancel_payslips"
+                    >
                         <div class="col-lg-6 col-12 o_setting_box">
                             <div class="o_setting_left_pane">
                                 <field name="allow_cancel_payslips" />
@@ -63,12 +66,15 @@
                             <div class="o_setting_right_pane">
                                 <label for="allow_cancel_payslips" />
                                 <div class="text-muted">
-                                    If enabled, confirmed payslips can be canceled by the user. Default: Not enabled.
+                                    Allow users to cancel confirmed payslips
                                 </div>
                             </div>
                         </div>
                     </div>
-                    <div class="row mt16 o_settings_container" id="compute_on_confirm">
+                    <div
+                        class="row mt16 o_settings_container"
+                        id="prevent_compute_on_confirm"
+                    >
                         <div class="col-lg-6 col-12 o_setting_box">
                             <div class="o_setting_left_pane">
                                 <field name="prevent_compute_on_confirm" />
@@ -76,12 +82,15 @@
                             <div class="o_setting_right_pane">
                                 <label for="prevent_compute_on_confirm" />
                                 <div class="text-muted">
-                                    If enabled, this setting will prevent the payslip to be re-computed on confirm.
+                                    Prevent payslips from being recomputed when confirming them
                                 </div>
                             </div>
                         </div>
                     </div>
-                    <div class="row mt16 o_settings_container" id="editing_lines">
+                    <div
+                        class="row mt16 o_settings_container"
+                        id="allow_edit_payslip_lines"
+                    >
                         <div class="col-lg-6 col-12 o_setting_box">
                             <div class="o_setting_left_pane">
                                 <field name="allow_edit_payslip_lines" />
@@ -89,7 +98,24 @@
                             <div class="o_setting_right_pane">
                                 <label for="allow_edit_payslip_lines" />
                                 <div class="text-muted">
-                                    Allow editing payslip lines manually in views and forms
+                                    Allow users to edit some payslip line fields manually
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <h2>Features</h2>
+                    <div
+                        class="row mt16 o_settings_container"
+                        id="show_details_by_salary_rule_category"
+                    >
+                        <div class="col-lg-6 col-12 o_setting_box">
+                            <div class="o_setting_left_pane">
+                                <field name="show_details_by_salary_rule_category" />
+                            </div>
+                            <div class="o_setting_right_pane">
+                                <label for="show_details_by_salary_rule_category" />
+                                <div class="text-muted">
+                                    Show details by salary rule category
                                 </div>
                             </div>
                         </div>

--- a/payroll/views/res_config_settings_views.xml
+++ b/payroll/views/res_config_settings_views.xml
@@ -103,6 +103,23 @@
                             </div>
                         </div>
                     </div>
+                    <div
+                        class="row mt16 o_settings_container"
+                        id="require_code_and_category"
+                    >
+                        <div class="col-lg-6 col-12 o_setting_box">
+                            <div class="o_setting_left_pane">
+                                <field name="require_code_and_category" />
+                            </div>
+                            <div class="o_setting_right_pane">
+                                <label for="require_code_and_category" />
+                                <div class="text-muted">
+                                    Require rule.code, rule.category, category.code, structure.code
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+
                 </div>
             </xpath>
         </field>

--- a/payroll_account/models/hr_payroll_account.py
+++ b/payroll_account/models/hr_payroll_account.py
@@ -104,7 +104,7 @@ class HrPayslip(models.Model):
                 "journal_id": slip.journal_id.id,
                 "date": date,
             }
-            for line in slip.details_by_salary_rule_category:
+            for line in slip.line_ids:
                 amount = currency.round(slip.credit_note and -line.total or line.total)
                 if currency.is_zero(amount):
                     continue


### PR DESCRIPTION
See PR #72 and the discussion in issue #92

**Multi-company**: I have added hr_payslip_run.company_id

**Settings**: I have added a setting for "details by salary rule category". I have also rewritten some descriptions.

**Codes**: I have set `required=False` on

* hr_salary_rule.code
* hr_salary_rule.category
* hr_salary_rule_category.code
* hr_payroll_structure.code

@mtelahun @nimarosa @pedrobaeza Is this ok with you?
Existing tests are passing, and a manual test also worked well.