### PR TITLE
[14.0] [IMP] payroll: improve security

### DIFF
--- a/payroll/security/hr_payroll_security.xml
+++ b/payroll/security/hr_payroll_security.xml
@@ -25,9 +25,7 @@
         </record>
         <!-- Allow python editing -->
         <record id="group_payroll_allow_python" model="res.groups">
-            <field
-                name="name"
-            >Payroll: Allow editing python code in salary rules</field>
+            <field name="name">Payroll: Access to python code in salary rules</field>
             <field name="category_id" ref="base.module_category_hidden" />
             <field name="implied_ids" eval="[(4, ref('payroll.group_payroll_user'))]" />
         </record>

--- a/payroll/security/hr_payroll_security.xml
+++ b/payroll/security/hr_payroll_security.xml
@@ -23,6 +23,12 @@
                 eval="[(4, ref('base.user_root')), (4, ref('base.user_admin'))]"
             />
         </record>
+        <!-- Allow python editing -->
+        <record id="group_payroll_allow_python" model="res.groups">
+            <field name="name">Payroll: Allow to edit python code in rules</field>
+            <field name="category_id" ref="base.module_category_hidden" />
+            <field name="implied_ids" eval="[(4, ref('payroll.group_payroll_user'))]" />
+        </record>
         <record id="base.default_user" model="res.users">
             <field name="groups_id" eval="[(4,ref('payroll.group_payroll_manager'))]" />
         </record>

--- a/payroll/security/hr_payroll_security.xml
+++ b/payroll/security/hr_payroll_security.xml
@@ -25,7 +25,9 @@
         </record>
         <!-- Allow python editing -->
         <record id="group_payroll_allow_python" model="res.groups">
-            <field name="name">Payroll: Allow to edit python code in rules</field>
+            <field
+                name="name"
+            >Payroll: Allow editing python code in salary rules</field>
             <field name="category_id" ref="base.module_category_hidden" />
             <field name="implied_ids" eval="[(4, ref('payroll.group_payroll_user'))]" />
         </record>

--- a/payroll/security/ir.model.access.csv
+++ b/payroll/security/ir.model.access.csv
@@ -9,8 +9,8 @@ access_hr_payslip_input_user,hr.payslip.input.user,model_hr_payslip_input,payrol
 access_hr_payslip_worked_days_officer,hr.payslip.worked_days.officer,model_hr_payslip_worked_days,payroll.group_payroll_user,1,1,1,1
 access_hr_payslip_run,hr.payslip.run,model_hr_payslip_run,payroll.group_payroll_manager,1,1,1,1
 access_hr_rule_input_officer,hr.rule.input.office,model_hr_rule_input,payroll.group_payroll_user,1,1,1,1
-access_hr_salary_rule_user,hr.salary.rule user,model_hr_salary_rule,payroll.group_payroll_user,1,0,0,0
-access_hr_salary_rule_manager,hr.salary.rule manager,model_hr_salary_rule,payroll.group_payroll_manager,1,1,1,1
+access_hr_salary_rule_user,hr.salary.rule.user,model_hr_salary_rule,payroll.group_payroll_user,1,0,0,0
+access_hr_salary_rule_manager,hr.salary.rule.manager,model_hr_salary_rule,payroll.group_payroll_manager,1,1,1,1
 access_hr_payslip_batch_employees_transient,hr.payslip.employees.batch,model_hr_payslip_employees,hr.group_hr_user,1,1,1,0
 access_hr_payslip_lines_contribution_register_transient,payslip.lines.contribution.register,model_payslip_lines_contribution_register,hr.group_hr_user,1,1,1,0
 access_hr_payslip_change_state,access_hr_payslip_change_state,model_hr_payslip_change_state,base.group_user,1,1,1,0

--- a/payroll/views/hr_salary_rule_views.xml
+++ b/payroll/views/hr_salary_rule_views.xml
@@ -138,18 +138,18 @@
                                         groups="payroll.group_payroll_allow_python"
                                     />
                                     <div
-                                        class="alert alert-danger"
+                                        class="alert alert-info"
                                         groups="!payroll.group_payroll_allow_python"
-                                        attrs="{'invisible':[('condition_select','!=','python')], 'required': [('condition_select','=','python')]}"
+                                        attrs="{'invisible':[('amount_select','!=','python')]}"
                                         role="alert"
                                     >
                                     <p>
-                                        <h4><strong>Security Notice</strong></h4><br />
+                                        <h3><strong>Security Notice</strong></h3>
+                                        <hr />
                                         <strong
-                                            >You are NOT allowed to see the rule python code.</strong><br
-                                            />
-                                        Salary rule code view and editing is only allowed to users with the required specific access rights.
-                                        If you think there is an error, ask your system adminsitrator.
+                                            >For security reasons, access to python code is restricted.</strong>
+                                            <i
+                                            > If you think there is an error, please ask your system administrator.</i>
                                     </p>
                                     </div>
                                     <field
@@ -209,18 +209,18 @@
                                         groups="payroll.group_payroll_allow_python"
                                     />
                                     <div
-                                        class="alert alert-danger"
+                                        class="alert alert-info"
                                         groups="!payroll.group_payroll_allow_python"
-                                        attrs="{'invisible':[('amount_select','!=','code')], 'required':[('amount_select','=','code')]}"
+                                        attrs="{'invisible':[('amount_select','!=','code')]}"
                                         role="alert"
                                     >
                                     <p>
-                                        <h4><strong>Security Notice</strong></h4><br />
+                                        <h3><strong>Security Notice</strong></h3>
+                                        <hr />
                                         <strong
-                                            >You are NOT allowed to see the rule python code.</strong><br
-                                            />
-                                        Salary rule code view and editing is only allowed to users with the required specific access rights.
-                                        If you think there is an error, ask your system adminsitrator.
+                                            >For security reasons, access to python code is restricted.</strong>
+                                            <i
+                                            > If you think there is an error, please ask your system administrator.</i>
                                     </p>
                                     </div>
                                     <field

--- a/payroll/views/hr_salary_rule_views.xml
+++ b/payroll/views/hr_salary_rule_views.xml
@@ -135,7 +135,23 @@
                                         options="{'mode': 'python'}"
                                         id="condition_python"
                                         nolabel="1"
+                                        groups="payroll.group_payroll_allow_python"
                                     />
+                                    <div
+                                        class="alert alert-danger"
+                                        groups="!payroll.group_payroll_allow_python"
+                                        attrs="{'invisible':[('condition_select','!=','python')], 'required': [('condition_select','=','python')]}"
+                                        role="alert"
+                                    >
+                                    <p>
+                                        <h4><strong>Security Notice</strong></h4><br />
+                                        <strong
+                                            >You are NOT allowed to see rule code.</strong><br
+                                            />
+                                        Salary rule code view and editing is only allowed to user with the required access rights.
+                                        If you think there is an error, ask your system adminsitrator.
+                                    </p>
+                                    </div>
                                     <field
                                         name="condition_range"
                                         attrs="{'invisible':[('condition_select','!=','range')], 'required':[('condition_select','=','range')]}"
@@ -190,7 +206,23 @@
                                         options="{'mode': 'python'}"
                                         id="amount_python_compute"
                                         nolabel="1"
+                                        groups="payroll.group_payroll_allow_python"
                                     />
+                                    <div
+                                        class="alert alert-danger"
+                                        groups="!payroll.group_payroll_allow_python"
+                                        attrs="{'invisible':[('amount_select','!=','code')], 'required':[('amount_select','=','code')]}"
+                                        role="alert"
+                                    >
+                                    <p>
+                                        <h4><strong>Security Notice</strong></h4><br />
+                                        <strong
+                                            >You are NOT allowed to see rule code.</strong><br
+                                            />
+                                        Salary rule code view and editing is only allowed to user with the required access rights.
+                                        If you think there is an error, ask your system adminsitrator.
+                                    </p>
+                                    </div>
                                     <field
                                         name="amount_percentage"
                                         attrs="{'invisible':[('amount_select','!=','percentage')], 'required':[('amount_select','=','percentage')]}"

--- a/payroll/views/hr_salary_rule_views.xml
+++ b/payroll/views/hr_salary_rule_views.xml
@@ -146,9 +146,9 @@
                                     <p>
                                         <h4><strong>Security Notice</strong></h4><br />
                                         <strong
-                                            >You are NOT allowed to see rule code.</strong><br
+                                            >You are NOT allowed to see the rule python code.</strong><br
                                             />
-                                        Salary rule code view and editing is only allowed to user with the required access rights.
+                                        Salary rule code view and editing is only allowed to users with the required specific access rights.
                                         If you think there is an error, ask your system adminsitrator.
                                     </p>
                                     </div>
@@ -217,9 +217,9 @@
                                     <p>
                                         <h4><strong>Security Notice</strong></h4><br />
                                         <strong
-                                            >You are NOT allowed to see rule code.</strong><br
+                                            >You are NOT allowed to see the rule python code.</strong><br
                                             />
-                                        Salary rule code view and editing is only allowed to user with the required access rights.
+                                        Salary rule code view and editing is only allowed to users with the required specific access rights.
                                         If you think there is an error, ask your system adminsitrator.
                                     </p>
                                     </div>


### PR DESCRIPTION
Hello, this commit purpose is to improve security rules and add more restriction specially to editing python rules. 

I will be making another tweaks to it in the following days, for now the changes are: 

- Created a new group, which is a hidden one (can only be activated in the user form, while being in developer mode and with a checkbox)
- Users with this group, will be the only who can see the "python code" fields. 
- Other users, including the payroll manager, will see an error message it's shown in the following screenshot: 
<img width="1658" alt="Screen Shot 2022-11-08 at 18 03 45" src="https://user-images.githubusercontent.com/12401188/200674994-0388dd1b-1f41-40b8-b0b8-0be777d46a8b.png">

This is to make the user understand why he can't see the python code field, and don't believe it's a bug. 
I have the intention of doing some tweaks to the other existing groups, so we can have very detailed and extensive security rules and groups, that could prevent the most any exploit of python safe_eval functionality. We will achieve that by limiting the roles, specially with all python related stuff, but not limited to. 

Keep posted for more commits. 