### PR TITLE
[14.0][FIX] payroll: make _get_employee_contracts() idempotent

### DIFF
--- a/payroll/models/hr_payslip.py
+++ b/payroll/models/hr_payslip.py
@@ -712,12 +712,11 @@ class HrPayslip(models.Model):
     def _get_employee_contracts(self):
         contracts = self.env["hr.contract"]
         for payslip in self:
-            if payslip.contract_id.ids:
+            contracts |= payslip.employee_id._get_contracts(
+                date_from=payslip.date_from, date_to=payslip.date_to
+            )
+            if not contracts and payslip.contract_id.ids:
                 contracts |= payslip.contract_id
-            else:
-                contracts |= payslip.employee_id._get_contracts(
-                    date_from=payslip.date_from, date_to=payslip.date_to
-                )
         return contracts
 
     @api.onchange("struct_id")


### PR DESCRIPTION
The method _get_employee_contracts() returns the contracts that apply to the payslip's period (date_start - date_end). It should return the same values for a payslip everytime it is run (so long as the employee's contracts haven't changed). Currently it first checks the contract_id field of the payslip and if it finds a contract it returns that, otherwise, it retruns the values returned by the _get_contracts() method of the employee object. The first time _get_employee_contracts() runs after the payslip is created the contract_id field is empty so it gets its values from the employee object (and usually the calling function will then set contract_id). On subsequent runs because the contract_id field is now valid it will return the content of that field even if there may be other valid contracts in the period.
To fix this I just reversed the order of the comparisons. It will first check _get_contracts() of the employee object and only if it doesn't get any results will it check the contract_id field.