### PR TITLE
[14.0] [FIX] payroll_rule_time_parameters: Add rule_parameter method

### DIFF
--- a/payroll_rule_time_parameter/__init__.py
+++ b/payroll_rule_time_parameter/__init__.py
@@ -1,1 +1,2 @@
 from .hooks import pre_init_hook
+from . import models

--- a/payroll_rule_time_parameter/models/__init__.py
+++ b/payroll_rule_time_parameter/models/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (C) 2021 Nimarosa (Nicolas Rodriguez) (<nicolasrsande@gmail.com>).
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from . import hr_payslip

--- a/payroll_rule_time_parameter/models/hr_payslip.py
+++ b/payroll_rule_time_parameter/models/hr_payslip.py
@@ -7,9 +7,11 @@ from odoo import models
 class HrPayslip(models.Model):
     _inherit = "hr.payslip"
 
-    def rule_parameter(self, code, return_type="float"):
+    def rule_parameter(self, code, date=False, return_type="float"):
         self.ensure_one()
-        time_parameter = self.get_time_parameter(code, date=self.date_from)
+        if not date:
+            date = self.date_from
+        time_parameter = self.get_time_parameter(code, date=date)
         return (
             return_type == "float" and float(time_parameter) or time_parameter or 0.00
         )

--- a/payroll_rule_time_parameter/models/hr_payslip.py
+++ b/payroll_rule_time_parameter/models/hr_payslip.py
@@ -1,0 +1,15 @@
+# Copyright (C) 2021 Nimarosa (Nicolas Rodriguez) (<nicolasrsande@gmail.com>).
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import models
+
+
+class HrPayslip(models.Model):
+    _inherit = "hr.payslip"
+
+    def rule_parameter(self, code, return_type="float"):
+        self.ensure_one()
+        time_parameter = self.get_time_parameter(code, date=self.date_from)
+        return (
+            return_type == "float" and float(time_parameter) or time_parameter or 0.00
+        )


### PR DESCRIPTION
Here we add the rule_parameter method to the new parameters module for two reasons: 

- Mantain old rules calling rule_parameter from the code. I had problem with people getting used to the new sintax so for now the method will remain the same in payslip, and call get_time_parameter from inside.
- In salary rules we almost always need float values. I don't know if you @norlinhenrik made the value field as text for any of your requirements, so for now, we default to float only in payroll implementation. Maybe in the future we can improve this in base_time_parameter. 

Regards.