### PR TITLE
[14.0] [IMP] payroll_rule_time_parameter: Improve rule_parameter function

### DIFF
--- a/payroll/migrations/move_records.py
+++ b/payroll/migrations/move_records.py
@@ -57,7 +57,7 @@ def move_records(cr, legacy):
 
     sql_insert_versions = """
     INSERT INTO base_time_parameter_version (
-        parameter_id, company_id, code, date_from, value_text
+        parameter_id, company_id, code, date_from, value
     )
     VALUES {versions}
     """.format(

--- a/payroll_rule_time_parameter/models/hr_payslip.py
+++ b/payroll_rule_time_parameter/models/hr_payslip.py
@@ -7,9 +7,9 @@ from odoo import models
 class HrPayslip(models.Model):
     _inherit = "hr.payslip"
 
-    def rule_parameter(self, code, date=False, data_type="value"):
+    def rule_parameter(self, code, date=False, get="value"):
         self.ensure_one()
         if not date:
             date = self.date_from
-        time_parameter = self.get_time_parameter(code, date=date, data_type=data_type)
+        time_parameter = self.get_time_parameter(code, date=date, get=get)
         return time_parameter

--- a/payroll_rule_time_parameter/models/hr_payslip.py
+++ b/payroll_rule_time_parameter/models/hr_payslip.py
@@ -7,11 +7,9 @@ from odoo import models
 class HrPayslip(models.Model):
     _inherit = "hr.payslip"
 
-    def rule_parameter(self, code, date=False, return_type="float"):
+    def rule_parameter(self, code, date=False, data_type="value"):
         self.ensure_one()
         if not date:
             date = self.date_from
-        time_parameter = self.get_time_parameter(code, date=date)
-        return (
-            return_type == "float" and float(time_parameter) or time_parameter or 0.00
-        )
+        time_parameter = self.get_time_parameter(code, date=date, data_type=data_type)
+        return time_parameter

--- a/payroll_rule_time_parameter/tests/test_time_parameter.py
+++ b/payroll_rule_time_parameter/tests/test_time_parameter.py
@@ -11,9 +11,9 @@ class TestTimeParameter(TransactionCase):
         self.env["base.time.parameter"].create(
             {
                 "code": "TEST_CODE",
-                "type": "text",
+                "type": "string",
                 "version_ids": [
-                    (0, 0, {"date_from": date(2022, 1, 1), "value_text": "TEST_VALUE"})
+                    (0, 0, {"date_from": date(2022, 1, 1), "value": "TEST_VALUE"})
                 ],
             }
         )


### PR DESCRIPTION
Remove float since now it's included in base_time_parameter. 
Improve function to support date_type searches. 

Must be merged after https://github.com/OCA/server-tools/pull/2470