### PR TITLE
[14.0] [IMP] payroll: Add new "payslips" object methods

### DIFF
--- a/payroll/models/base_browsable.py
+++ b/payroll/models/base_browsable.py
@@ -100,7 +100,7 @@ class Payslips(BrowsableObject):
         res = self.env.cr.fetchone()
         return res and res[0] or 0.0
 
-    def rule_max(self, code, from_date, to_date=None):
+    def max_rule(self, code, from_date, to_date=None):
         if to_date is None:
             to_date = fields.Date.today()
         self.env.cr.execute(
@@ -144,7 +144,7 @@ class Payslips(BrowsableObject):
         res = self.env.cr.fetchone()
         return res and res[0] or 0.0
 
-    def category_max(self, code, from_date, to_date=None):
+    def max_category(self, code, from_date, to_date=None):
         if to_date is None:
             to_date = fields.Date.today()
 

--- a/payroll/models/base_browsable.py
+++ b/payroll/models/base_browsable.py
@@ -100,6 +100,21 @@ class Payslips(BrowsableObject):
         res = self.env.cr.fetchone()
         return res and res[0] or 0.0
 
+    def rule_max(self, code, from_date, to_date=None):
+        if to_date is None:
+            to_date = fields.Date.today()
+        self.env.cr.execute(
+            """SELECT max(case when hp.credit_note = False then
+            (pl.total) else (-pl.total) end)
+                    FROM hr_payslip as hp, hr_payslip_line as pl
+                    WHERE hp.employee_id = %s AND hp.state = 'done'
+                    AND hp.date_from >= %s AND hp.date_to <= %s AND
+                     hp.id = pl.slip_id AND pl.code = %s""",
+            (self.employee_id, from_date, to_date, code),
+        )
+        res = self.env.cr.fetchone()
+        return res and res[0] or 0.0
+
     def sum_category(self, code, from_date, to_date=None):
         if to_date is None:
             to_date = fields.Date.today()
@@ -119,6 +134,29 @@ class Payslips(BrowsableObject):
 
         self.env.cr.execute(
             """SELECT sum(case when hp.credit_note is not True then
+            (pl.total) else (-pl.total) end)
+                    FROM hr_payslip as hp, hr_payslip_line as pl, hr_salary_rule_category as rc
+                    WHERE hp.employee_id = %s AND hp.state = 'done'
+                    AND hp.date_from >= %s AND hp.date_to <= %s AND hp.id = pl.slip_id
+                    AND rc.id = pl.category_id AND rc.code in %s""",
+            (self.employee_id, from_date, to_date, tuple(hicherarchy_codes)),
+        )
+        res = self.env.cr.fetchone()
+        return res and res[0] or 0.0
+
+    def category_max(self, code, from_date, to_date=None):
+        if to_date is None:
+            to_date = fields.Date.today()
+
+        hicherarchy_codes = (
+            self.env["hr.salary.rule.category"]
+            .search([("code", "=", code)])
+            .children_ids.mapped("code")
+        )
+        hicherarchy_codes.append(code)
+
+        self.env.cr.execute(
+            """SELECT max(case when hp.credit_note is not True then
             (pl.total) else (-pl.total) end)
                     FROM hr_payslip as hp, hr_payslip_line as pl, hr_salary_rule_category as rc
                     WHERE hp.employee_id = %s AND hp.state = 'done'

--- a/payroll/models/base_browsable.py
+++ b/payroll/models/base_browsable.py
@@ -115,6 +115,21 @@ class Payslips(BrowsableObject):
         res = self.env.cr.fetchone()
         return res and res[0] or 0.0
 
+    def min_rule(self, code, from_date, to_date=None):
+        if to_date is None:
+            to_date = fields.Date.today()
+        self.env.cr.execute(
+            """SELECT min(case when hp.credit_note = False then
+            (pl.total) else (-pl.total) end)
+                    FROM hr_payslip as hp, hr_payslip_line as pl
+                    WHERE hp.employee_id = %s AND hp.state = 'done'
+                    AND hp.date_from >= %s AND hp.date_to <= %s AND
+                     hp.id = pl.slip_id AND pl.code = %s""",
+            (self.employee_id, from_date, to_date, code),
+        )
+        res = self.env.cr.fetchone()
+        return res and res[0] or 0.0
+
     def sum_category(self, code, from_date, to_date=None):
         if to_date is None:
             to_date = fields.Date.today()
@@ -157,6 +172,29 @@ class Payslips(BrowsableObject):
 
         self.env.cr.execute(
             """SELECT max(case when hp.credit_note is not True then
+            (pl.total) else (-pl.total) end)
+                    FROM hr_payslip as hp, hr_payslip_line as pl, hr_salary_rule_category as rc
+                    WHERE hp.employee_id = %s AND hp.state = 'done'
+                    AND hp.date_from >= %s AND hp.date_to <= %s AND hp.id = pl.slip_id
+                    AND rc.id = pl.category_id AND rc.code in %s""",
+            (self.employee_id, from_date, to_date, tuple(hicherarchy_codes)),
+        )
+        res = self.env.cr.fetchone()
+        return res and res[0] or 0.0
+
+    def min_category(self, code, from_date, to_date=None):
+        if to_date is None:
+            to_date = fields.Date.today()
+
+        hicherarchy_codes = (
+            self.env["hr.salary.rule.category"]
+            .search([("code", "=", code)])
+            .children_ids.mapped("code")
+        )
+        hicherarchy_codes.append(code)
+
+        self.env.cr.execute(
+            """SELECT min(case when hp.credit_note is not True then
             (pl.total) else (-pl.total) end)
                     FROM hr_payslip as hp, hr_payslip_line as pl, hr_salary_rule_category as rc
                     WHERE hp.employee_id = %s AND hp.state = 'done'

--- a/payroll/models/base_browsable.py
+++ b/payroll/models/base_browsable.py
@@ -100,6 +100,21 @@ class Payslips(BrowsableObject):
         res = self.env.cr.fetchone()
         return res and res[0] or 0.0
 
+    def average_rule(self, code, from_date, to_date=None):
+        if to_date is None:
+            to_date = fields.Date.today()
+        self.env.cr.execute(
+            """SELECT avg(case when hp.credit_note = False then
+            (pl.total) else (-pl.total) end)
+                    FROM hr_payslip as hp, hr_payslip_line as pl
+                    WHERE hp.employee_id = %s AND hp.state = 'done'
+                    AND hp.date_from >= %s AND hp.date_to <= %s AND
+                     hp.id = pl.slip_id AND pl.code = %s""",
+            (self.employee_id, from_date, to_date, code),
+        )
+        res = self.env.cr.fetchone()
+        return res and res[0] or 0.0
+
     def max_rule(self, code, from_date, to_date=None):
         if to_date is None:
             to_date = fields.Date.today()
@@ -149,6 +164,29 @@ class Payslips(BrowsableObject):
 
         self.env.cr.execute(
             """SELECT sum(case when hp.credit_note is not True then
+            (pl.total) else (-pl.total) end)
+                    FROM hr_payslip as hp, hr_payslip_line as pl, hr_salary_rule_category as rc
+                    WHERE hp.employee_id = %s AND hp.state = 'done'
+                    AND hp.date_from >= %s AND hp.date_to <= %s AND hp.id = pl.slip_id
+                    AND rc.id = pl.category_id AND rc.code in %s""",
+            (self.employee_id, from_date, to_date, tuple(hicherarchy_codes)),
+        )
+        res = self.env.cr.fetchone()
+        return res and res[0] or 0.0
+
+    def average_category(self, code, from_date, to_date=None):
+        if to_date is None:
+            to_date = fields.Date.today()
+
+        hicherarchy_codes = (
+            self.env["hr.salary.rule.category"]
+            .search([("code", "=", code)])
+            .children_ids.mapped("code")
+        )
+        hicherarchy_codes.append(code)
+
+        self.env.cr.execute(
+            """SELECT avg(case when hp.credit_note is not True then
             (pl.total) else (-pl.total) end)
                     FROM hr_payslip as hp, hr_payslip_line as pl, hr_salary_rule_category as rc
                     WHERE hp.employee_id = %s AND hp.state = 'done'

--- a/payroll/models/base_browsable.py
+++ b/payroll/models/base_browsable.py
@@ -85,7 +85,7 @@ class Payslips(BrowsableObject):
     """a class that will be used into the python code, mainly for
     usability purposes"""
 
-    def sum(self, code, from_date, to_date=None):
+    def sum_rule(self, code, from_date, to_date=None):
         if to_date is None:
             to_date = fields.Date.today()
         self.env.cr.execute(
@@ -99,6 +99,12 @@ class Payslips(BrowsableObject):
         )
         res = self.env.cr.fetchone()
         return res and res[0] or 0.0
+
+    def sum(self, code, from_date, to_date=None):
+        _logger.warning(
+            "Payslips Object: sum() method is DEPRECATED. Use sum_rule() instead."
+        )
+        return self.sum_rule(code, from_date, to_date)
 
     def average_rule(self, code, from_date, to_date=None):
         if to_date is None:

--- a/payroll/models/hr_payslip.py
+++ b/payroll/models/hr_payslip.py
@@ -491,7 +491,10 @@ class HrPayslip(models.Model):
     def _get_tools_dict(self):
         # _get_tools_dict() is intended to be inherited by other private modules
         # to add tools or python libraries available in localdict
-        return {"math": math}  # "math" object is useful for doing calculations
+        return {
+            "math": math,
+            "datetime": datetime,
+        }  # "math" object is useful for doing calculations
 
     def _get_baselocaldict(self, contracts):
         self.ensure_one()

--- a/payroll/views/hr_payslip_views.xml
+++ b/payroll/views/hr_payslip_views.xml
@@ -243,15 +243,17 @@
                             </field>
                         </page>
                         <page name="computation" string="Salary Computation">
-                            <group>
-                                <field
-                                    name="hide_child_lines"
-                                    widget="boolean_toggle"
-                                />
-                                <field
-                                    name="hide_invisible_lines"
-                                    widget="boolean_toggle"
-                                />
+                            <group name="controls">
+                                <group>
+                                    <field
+                                        name="hide_child_lines"
+                                        widget="boolean_toggle"
+                                    />
+                                    <field
+                                        name="hide_invisible_lines"
+                                        widget="boolean_toggle"
+                                    />
+                                </group>
                             </group>
                             <field
                                 name="dynamic_filtered_payslip_lines"


### PR DESCRIPTION
Hello, this PR is intended to add new functionalities to the "payslips" object.

By default, "payslips" object have the "sum" method, which you need to pass a code and a date (and optionally a to_date) and the function will sum all rules with that code and return the summed value. This is useful if you need the ytd, mtd or just the sum of some rule to calculate a salary rules. Following this approach, the new functionalities introduced in this PR are: 

- The "payslips" object methods requiere dates as a param, so it's useful to add "datetime" object to the tools dict. This will make things like this possible: 

```python
# Inside salary rule code
from_date = tools.datetime(2022, 01, 01) # from_date is a datetime object that can be easily passed as param

# PRO Tip: 
# You can also get payslip dates that are useful to use as params using: 
payslip_start_date = payslip.date_from # "datetime" object
payslip_stop_date = payslip.date_to  # "datetime" object
```

- Add "sum_category" method. This method allows the user to get the sum of rules that have the passed category between a time frame. Usage is as following example, inside salary rule code: 
```python
# Get the average gross between a time period, date_from and current date
date_from = tools.datetime(2022, 1, 1)
gross_category_sum = payslips.sum_category("GROSS", date_from, payslip.date_to) 
result = gross_category_sum / 12 

# There are a lot of usages of this, this example is used to get the average GROSS category sum salary between two dates. 
# The method also consider hierarchical structure of rules, so if you have rules that have the GROSS category as
# parent_rule_id, they will be also summed to get the correct value. 
```

- Add "max_category" and "max_rule" method. This methods return the max value of a category (or rule if using max_rule) between a time period: 
```python
# Get the max "GROSS" category amount from payslips between start of the year and current date.
date_from = tools.datetime(2022, 1, 1)
result = payslips.max_category("GROSS", date_from) # "result" will contain the max value of the category in the selected time frame payslips

# Get the max "BASIC" rule amount from payslips
result = payslips.max_rule("BASIC", date_from) # "result" will contain the max value of the rule in the selected time frame payslips
```

- Add "min_category" and "min_rule" method. As "max_category" and "min_rule" methods, this one returns the min value of the selected category/payslips depending of the function used. Example are the same as the last ones, but using the "min_***" methods. 

- Add "average_category" and "average_rule" methods. This methods, will calculate the average value of a category (or a rule if you are using the rule method) between a given time period. An example of it could be:
```python
# Get the average "GROSS" category amount from payslips between start of the year and current date.
date_from = tools.datetime(2022, 1, 1)
result = payslips.average_category("GROSS", date_from) # "result" will contain the average value of the category in the selected time frame payslips

# Get the average "BASIC" rule amount from payslips
result = payslips.average_rule("BASIC", date_from) # "result" will contain the average value of the rule in the selected time frame payslips
```

- Add "average_xxx_monthly", "max_xxx_monthly" and "min_xxx_monthly"  methods. This methods have the same params and syntax that previous ones, with the difference that they return average/max/min on monthly basis. Meaning that function first sums monthly payslips and then applies functions to get max/min/average. This functions are useful for cases when the employee has more than one payslip per month, and you need to get monthly variables. 

---

This changes also are motivated by the need to reduce the "env" object usage. If some user need to get maximum or sum values, he will use the "env" object to execute a query. As discussed in #94 the usage of "env" is not the best for security, so writing more methods that execute common queries will reduce the use of that object. If we continue doing useful functions for the Browsable Objects, we can think in removing env access in the future. 

Regards. 
