### PR TITLE
[IMP][14.0] hr_payroll_period: use hr_period_id.name in _compute_name()

### DIFF
--- a/hr_payroll_period/models/hr_payslip.py
+++ b/hr_payroll_period/models/hr_payslip.py
@@ -79,3 +79,10 @@ class HrPayslip(models.Model):
         elif vals.get("date_to") and not vals.get("date_payment"):
             vals["date_payment"] = vals["date_to"]
         return super(HrPayslip, self).create(vals)
+
+    def _compute_name(self):
+        for record in self:
+            record.name = _("Salary Slip of %s for %s") % (
+                record.employee_id.name, record.hr_period_id.name
+            )
+            

--- a/hr_payroll_period/models/hr_payslip.py
+++ b/hr_payroll_period/models/hr_payslip.py
@@ -83,6 +83,6 @@ class HrPayslip(models.Model):
     def _compute_name(self):
         for record in self:
             record.name = _("Salary Slip of %s for %s") % (
-                record.employee_id.name, record.hr_period_id.name
+                record.employee_id.name,
+                record.hr_period_id.name,
             )
-            


### PR DESCRIPTION
SInce hr_payroll_period has hr_period_id, therefore it's good to use hr_period_id.name as name of each payslip.

