### PR TITLE
[14.0][IMP] payroll: salary rule code: payslip.line_sum_where()

### DIFF
--- a/payroll/models/hr_payslip.py
+++ b/payroll/models/hr_payslip.py
@@ -804,3 +804,18 @@ class HrPayslip(models.Model):
             return line[0].total
         else:
             return 0.0
+
+    def line_sum_where(self, field_name, value, rules, result_rules):
+        """
+        The method may be used in salary rule code.
+        It will sum the total of the previously computed rules
+        where the given field has the given value.
+        E.g.: total_seq_10 = payslip.line_sum_where("sequence", 10, rules, result_rules)
+        """
+        return sum(
+            [
+                result_rules.dict[code].dict["total"]
+                for code, rule in rules.dict.items()
+                if getattr(rule, field_name) == value
+            ]
+        )

--- a/payroll/models/hr_payslip.py
+++ b/payroll/models/hr_payslip.py
@@ -556,10 +556,10 @@ class HrPayslip(models.Model):
         total = values["quantity"] * values["rate"] * values["amount"] / 100.0
         values["total"] = total
         # set/overwrite the amount computed for this rule in the localdict
-        if rule.code:
-            localdict[rule.code] = total
-            localdict["rules"].dict[rule.code] = rule
-            localdict["result_rules"].dict[rule.code] = BaseBrowsableObject(values)
+        code = rule.code or rule.id
+        localdict[code] = total
+        localdict["rules"].dict[code] = rule
+        localdict["result_rules"].dict[code] = BaseBrowsableObject(values)
         # sum the amount for its salary category
         localdict = self._sum_salary_rule_category(
             localdict, rule.category_id, total - previous_amount

--- a/payroll/tests/test_hr_salary_rule.py
+++ b/payroll/tests/test_hr_salary_rule.py
@@ -194,3 +194,48 @@ class TestSalaryRule(TestPayslipBase):
         self.assertEqual(len(line), 1, "Line found: rule without code")
         line = payslip.line_ids.filtered(lambda l: l.name == "rule without category")
         self.assertEqual(len(line), 1, "Line found: rule without category")
+
+    def test_line_sum_where(self):
+        rule_fix_1 = self.SalaryRule.create(
+            {
+                "name": "Fixed rule 1",
+                "sequence": 1,
+                "condition_select": "none",
+                "amount_select": "fix",
+                "amount_fix": 100.0,
+            }
+        )
+        rule_fix_2 = self.SalaryRule.create(
+            {
+                "name": "Fixed rule 2",
+                "sequence": 2,
+                "condition_select": "none",
+                "amount_select": "fix",
+                "amount_fix": 200.0,
+            }
+        )
+        rule_line_sum_where = self.Rule.create(
+            {
+                "name": "Total fixed values",
+                "sequence": 3,
+                "amount_select": "code",
+                "amount_python_compute": """result = payslip.line_sum_where(
+                    "amount_select", "fix", rules, result_rules
+                )""",
+            }
+        )
+        self.sales_pay_structure.rule_ids = [
+            (4, rule_fix_1.id),
+            (4, rule_fix_2.id),
+            (4, rule_line_sum_where.id),
+        ]
+        payslip = self.Payslip.create(
+            {
+                "employee_id": self.richard_emp.id,
+                "contract_id": self.richard_contract.id,
+                "struct_id": self.sales_pay_structure.id,
+            }
+        )
+        payslip.compute_sheet()
+        line = payslip.line_ids.filtered(lambda l: l.name == "Total fixed values")
+        self.assertEqual(line.total, 300, "Fixed rules: 100 + 200 = 300")

--- a/payroll/views/hr_salary_rule_views.xml
+++ b/payroll/views/hr_salary_rule_views.xml
@@ -237,6 +237,13 @@
                                         <li>
                                             <code
                                             >payslip:</code> contains current payslip object data (hr.payslip)
+                                            <ul>
+                                                <li>
+                                                    <code
+                                                    >payslip.line_sum_where(field_name, value, rules, result_rules)</code>
+                                                    Sum previously computed rules where the given field has the given value.
+                                                </li>
+                                            </ul>
                                         </li>
                                         <li>
                                             <code
@@ -295,15 +302,15 @@
                                         </li>
                                         <li>
                                             <code
-                                            >result_rate:</code> the rate that should be applied to "result"
+                                            >result_qty</code> (optional): the quantity of units that will be multiplied to "result"
                                         </li>
                                         <li>
                                             <code
-                                            >result_qty:</code> the quantity of units that will be multiplied to "result"
+                                            >result_rate</code> (optional): the rate that should be applied to "result"
                                         </li>
                                         <li>
                                             <code
-                                            >result_name:</code> overrides the current name of the rule and allows to make dynamic names
+                                            >result_name</code> (optional): overrides the current name of the rule and allows to make dynamic names
                                         </li>
                                     </ul>
                                     <h3>Examples</h3>
@@ -313,14 +320,17 @@
                                         </li>
                                         <li>
                                             <code>
-                                                result = contract.wage
                                                 result_qty = worked_days.WORK100.number_of_days
                                             </code>
                                         </li>
                                         <li>
                                             <code>
-                                                result = contract.wage
                                                 result_rate = 10.0
+                                            </code>
+                                        </li>
+                                        <li>
+                                            <code>
+                                                result_name = "Custom name"
                                             </code>
                                         </li>
                                     </ul>


### PR DESCRIPTION
payslip.line_sum_where() may be used in salary rule code.
It will sum the total of the previously computed rules where the given field has the given value.
`total_seq_10 = payslip.line_sum_where("sequence", 10, rules, result_rules)`

I have also improved the salary rule help text a little bit.