### PR TITLE
[FIX] payroll: show code field on hr.leave.type view

### DIFF
--- a/payroll/__manifest__.py
+++ b/payroll/__manifest__.py
@@ -38,7 +38,7 @@
         "views/res_config_settings_views.xml",
         "wizard/hr_payroll_send_email.xml",
         "wizard/hr_payslip_change_state_view.xml",
-        "views/hr_leave_type.xml"
+        "views/hr_leave_type.xml",
     ],
     "demo": ["demo/hr_payroll_demo.xml"],
     "application": True,

--- a/payroll/__manifest__.py
+++ b/payroll/__manifest__.py
@@ -38,6 +38,7 @@
         "views/res_config_settings_views.xml",
         "wizard/hr_payroll_send_email.xml",
         "wizard/hr_payslip_change_state_view.xml",
+        "views/hr_leave_type.xml"
     ],
     "demo": ["demo/hr_payroll_demo.xml"],
     "application": True,

--- a/payroll/views/hr_leave_type.xml
+++ b/payroll/views/hr_leave_type.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="hr_leave_type_view_form" model="ir.ui.view">
+        <field name="name">hr.leave.type.view.form.payroll</field>
+        <field name="model">hr.leave.type</field>
+        <field name="inherit_id" ref="hr_holidays.edit_holiday_status_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='time_type']" position="after">
+                <field name="code" />
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Impacted versions:

Odoo15 Community

Steps to reproduce:

go to menu Time Off Types and create a new record, the payroll code field won't show off

Expected behavior:

go to menu Time Off Types and create a new record, it will show the payroll code field

Description of the issue/feature this PR addresses:

Adds the field payroll code in the hr_leave_type_view_form view