### PR TITLE
[15.0][FIX] hr_perioll_period: fields definition

### DIFF
--- a/hr_payroll_period/models/hr_contract.py
+++ b/hr_payroll_period/models/hr_contract.py
@@ -11,4 +11,4 @@ class HrContract(models.Model):
     _inherit = "hr.contract"
 
     # Add semi-monthly to payroll schedules
-    schedule_pay = fields.Selection(get_schedules, oldname="shedule_pay", index=True)
+    schedule_pay = fields.Selection(get_schedules, index=True)

--- a/hr_payroll_period/models/hr_employee.py
+++ b/hr_payroll_period/models/hr_employee.py
@@ -7,7 +7,7 @@ from odoo import api, fields, models
 class HrEmployee(models.AbstractModel):
     _inherit = "hr.employee.base"
 
-    contract_id = fields.Many2one(search="_search_contract")
+    contract_id = fields.Many2one(comodel_name="hr.contract", search="_search_contract")
 
     @api.model
     def _search_contract(self, operator, value):


### PR DESCRIPTION
Otherwise you will see 2 warnings in the logs:

* field without comodel_name attribute
* unknown field attribute 'oldname'

@ForgeFlow