### PR TITLE
[14.0][FIX] hr_payroll_period: remove warnings

### DIFF
--- a/hr_payroll_period/migrations/14.0.1.0.0/pre-migration.py
+++ b/hr_payroll_period/migrations/14.0.1.0.0/pre-migration.py
@@ -1,0 +1,11 @@
+from odoo.tools.sql import column_exists, rename_column
+
+
+def migrate(cr, version):
+    if column_exists(cr, "hr_contract", "shedule_pay"):
+        rename_column(
+            cr,
+            "hr_contract",
+            "shedule_pay",
+            "schedule_pay",
+        )

--- a/hr_payroll_period/models/hr_contract.py
+++ b/hr_payroll_period/models/hr_contract.py
@@ -11,6 +11,4 @@ class HrContract(models.Model):
     _inherit = "hr.contract"
 
     # Add semi-monthly to payroll schedules
-    schedule_pay = fields.Selection(
-        get_schedules, "Scheduled Pay", oldname="shedule_pay", index=True
-    )
+    schedule_pay = fields.Selection(get_schedules, "Scheduled Pay", index=True)

--- a/hr_payroll_period/models/hr_employee.py
+++ b/hr_payroll_period/models/hr_employee.py
@@ -7,7 +7,7 @@ from odoo import api, fields, models
 class HrEmployee(models.AbstractModel):
     _inherit = "hr.employee.base"
 
-    contract_id = fields.Many2one(search="_search_contract")
+    contract_id = fields.Many2one(comodel_name="hr.contract", search="_search_contract")
 
     @api.model
     def _search_contract(self, operator, value):


### PR DESCRIPTION
Remove the following warnings from `hr_payroll_period` installation;

```
WARNING devel odoo.fields: Field hr.employee.base.contract_id with unknown comodel_name None 
WARNING devel odoo.fields: Field hr.employee.public.contract_id with unknown comodel_name None 
WARNING devel odoo.fields: Field hr.contract.schedule_pay: unknown parameter 'oldname', if this is an actual parameter you may want to override the method _valid_field_parameter on the relevant model in order to allow it
```
