### PR TITLE
[14.0][FIX]hr_payroll_period: remove required from hr.payslip(.run) view

### DIFF
--- a/hr_payroll_period/views/hr_payslip_view.xml
+++ b/hr_payroll_period/views/hr_payslip_view.xml
@@ -16,7 +16,7 @@
                 />
             </field>
             <field name="name" position="after">
-                <field name="date_payment" required="1" />
+                <field name="date_payment" />
             </field>
         </field>
     </record>


### PR DESCRIPTION
This PR removes the `required` attribute from the form views for `hr.payroll` and `hr.payroll.run` because they are not used