### PR TITLE
[FIX] payroll: properly show fields on contract

### DIFF
--- a/payroll/views/hr_contract_views.xml
+++ b/payroll/views/hr_contract_views.xml
@@ -6,10 +6,12 @@
         <field name="inherit_id" ref="hr_contract.hr_contract_view_form" />
         <field name="arch" type="xml">
             <xpath expr="//group[@name='salary_info']" position="inside">
-                <field name="schedule_pay" />
-                <field name="struct_id" required="1" />
-                <field name="company_id" groups="base.group_multi_company" />
-                <field name="currency_id" invisible="1" />
+                <group>
+                    <field name="schedule_pay" />
+                    <field name="struct_id" required="1" />
+                    <field name="company_id" groups="base.group_multi_company" />
+                    <field name="currency_id" invisible="1" />
+                </group>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
The payroll fields on the contract view were missing their labels.

**Before:**
![image](https://github.com/OCA/payroll/assets/50135801/9b293dae-d0d3-47e2-afa3-9afa90181129)

**After:**
![image](https://github.com/OCA/payroll/assets/50135801/68d4960a-0731-4f0c-9e75-b705dfb0e682)
