### PR TITLE
[18.0][REF] payroll:  use recordsets instead int lists

### DIFF
--- a/payroll/models/hr_contract.py
+++ b/payroll/models/hr_contract.py
@@ -38,8 +38,5 @@ class HrContract(models.Model):
                  hierachy (parent=False first, then first level children and
                  so on) and without duplicates
         """
-        structures = self.mapped("struct_id")
-        if not structures:
-            return []
-        # YTI TODO return browse records
-        return list(set(structures._get_parent_structure().ids))
+        # TODO: remove, too simple and not used
+        return self.struct_id.get_structure_with_parents()

--- a/payroll/models/hr_payroll_structure.py
+++ b/payroll/models/hr_payroll_structure.py
@@ -70,16 +70,12 @@ class HrPayrollStructure(models.Model):
 
     def get_all_rules(self):
         """
-        @return: returns a list of tuple (id, sequence) of rules that are maybe
-                 to apply
+        @return: recordset with all struct rules, ordered by sequence
         """
-        all_rules = []
-        for struct in self:
-            all_rules += struct.rule_ids._recursive_search_of_rules()
-        return all_rules
+        return self.rule_ids._recursive_search_of_rules().sorted("sequence")
 
-    def _get_parent_structure(self):
-        parent = self.mapped("parent_id")
-        if parent:
-            parent = parent._get_parent_structure()
-        return parent + self
+    def get_structure_with_parents(self):
+        if not self:
+            return self.env["hr.payroll.structure"]
+        else:
+            return self.parent_id.get_structure_with_parents() + self

--- a/payroll/models/hr_salary_rule.py
+++ b/payroll/models/hr_salary_rule.py
@@ -175,13 +175,13 @@ class HrSalaryRule(models.Model):
 
     def _recursive_search_of_rules(self):
         """
-        @return: returns a list of tuple (id, sequence) which are all the
-                 children of the passed rule_ids
+        Returns the rules in reverse dependency order, children first
+        @return: recordset of rules
         """
-        children_rules = []
-        for rule in self.filtered(lambda rule: rule.child_ids):
-            children_rules += rule.child_ids._recursive_search_of_rules()
-        return [(rule.id, rule.sequence) for rule in self] + children_rules
+        if not self:
+            return self.env["hr.salary.rule"]
+        else:
+            return self.child_ids._recursive_search_of_rules() | self
 
     def _reset_localdict_values(self, localdict):
         localdict["result_name"] = None

--- a/payroll/tests/test_payslip_flow.py
+++ b/payroll/tests/test_payslip_flow.py
@@ -243,15 +243,13 @@ class TestPayslipFlow(TestPayslipBase):
         )
 
     def test_get_contracts_multiple(self):
-        self.sally.contract_ids[0].date_end = (
-            Date.today() - timedelta(days=1)
-        ).strftime("%Y-%m-%d")
+        self.sally.contract_ids[0].date_end = Date.today().strftime("%Y-%m-01")
 
         self.Contract.create(
             {
                 "name": "Second contract for Sally",
                 "employee_id": self.sally.id,
-                "date_start": Date.today().strftime("%Y-%m-%d"),
+                "date_start": Date.today().strftime("%Y-%m-02"),
                 "struct_id": self.sales_pay_structure.id,
                 "wage": 6500.00,
                 "state": "open",


### PR DESCRIPTION
<s>I see there was a fix at https://github.com/OCA/payroll/pull/83, but in my tests this was not working.
I improved the tests for the child rule calculation dependencies, and now they are passing.</s>
