### PR TITLE
[18.0][FIX] payroll: error testing report printing

### DIFF
--- a/payroll/tests/test_payslip_flow.py
+++ b/payroll/tests/test_payslip_flow.py
@@ -161,6 +161,7 @@ class TestPayslipFlow(TestPayslipBase):
         context = {
             "model": "hr.contribution.register",
             "active_ids": [self.register_hra.id],
+            "discard_logo_check": True,
         }
         test_reports.try_report_action(
             self.env.cr,
@@ -169,6 +170,7 @@ class TestPayslipFlow(TestPayslipBase):
             context=context,
             our_module="payroll",
         )
+        # FIXME: try_report_action is not used anymore in the Odoo codebase
 
     def test_contract_qty(self):
         # I set the test rule to detect contract count


### PR DESCRIPTION
Before this fix, automated tests has this error:
```
2025-03-30 14:17:35,013 32750 INFO 18-oca odoo.addons.payroll.tests.test_payslip_flow: ======================================================
Traceback (most recent call last):
  File "/home/dreis/work18/oca/payroll/payroll/tests/test_payslip_flow.py", line 165, in test_00_payslip_flow
    result = _exec_action(action, datas, env)
  File "/home/dreis/work18/odoo/odoo/tools/test_reports.py", line 251, in _exec_action
    res = func()
  File "/home/dreis/work18/odoo/addons/account/wizard/base_document_layout.py", line 21, in document_layout_save
    res['context']['dialog_size'] = 'large'
NotImplementedError: '__setitem__' not supported on frozendict
```