### PR TITLE
[16.0][FIX] payroll: Fix tests (create allocation before leave)

### DIFF
--- a/payroll/tests/test_hr_payslip_worked_days.py
+++ b/payroll/tests/test_hr_payslip_worked_days.py
@@ -60,7 +60,15 @@ class TestWorkedDays(TestPayslipBase):
 
         # I put all eligible contracts (including Richard's) in an "open" state
         self.apply_contract_cron()
-
+        # Create allocation
+        allocation = self.env["hr.leave.allocation"].create(
+            {
+                "holiday_status_id": self.holiday_type.id,
+                "employee_id": self.richard_emp.id,
+                "date_from": date.today(),
+            }
+        )
+        allocation.action_confirm()
         # Create the leave
         self.LeaveRequest.create(
             {


### PR DESCRIPTION
Fix tests (create allocation before leave)

Related to https://github.com/odoo/odoo/pull/205504

This change is **NOT** necessary in 17.0 because it was already added in the migration https://github.com/OCA/payroll/commit/db0e54f4ce82de3ac772c3748c2904d425008e8c

Please @pedrobaeza and  @CarlosRoca13 can you review it?

@Tecnativa