### PR TITLE
[18.0][FIX] payroll_account: invoice_tax_id do not exists

### DIFF
--- a/payroll_account/models/hr_payslip.py
+++ b/payroll_account/models/hr_payslip.py
@@ -217,7 +217,7 @@ class HrPayslip(models.Model):
             TaxRepLine = self.env["account.tax.repartition.line"]
             tax_tag_ids = TaxRepLine.search(
                 [
-                    ("invoice_tax_id", "in", account_tax_ids),
+                    ("tax_id", "in", account_tax_ids),
                     ("repartition_type", "=", "base"),
                 ]
             ).tag_ids
@@ -227,7 +227,7 @@ class HrPayslip(models.Model):
             TaxRepLine = self.env["account.tax.repartition.line"]
             tax_repartition_line_id = TaxRepLine.search(
                 [
-                    ("invoice_tax_id", "=", salary_rule.account_tax_id.id),
+                    ("tax_id", "=", salary_rule.account_tax_id.id),
                     (
                         "account_id",
                         "=",
@@ -237,7 +237,7 @@ class HrPayslip(models.Model):
             ).id
             tax_tag_ids += TaxRepLine.search(
                 [
-                    ("invoice_tax_id", "=", salary_rule.account_tax_id.id),
+                    ("tax_id", "=", salary_rule.account_tax_id.id),
                     ("repartition_type", "=", "tax"),
                     (
                         "account_id",


### PR DESCRIPTION
In 16.0:
https://www.odoo.com/documentation/16.0/developer/reference/standard_modules/account/account_tax_repartition.html?highlight=invoice_tax_id#odoo.addons.account.models.chart_template.AccountTaxRepartitionLineTemplate.invoice_tax_id

In 18.0:
https://www.odoo.com/documentation/18.0/developer/reference/standard_modules/account/account_tax_repartition.html#odoo.addons.account.models.account_tax.AccountTaxRepartitionLine.tax_id