### PR TITLE
[IMP] payroll_account: use prepare methods in action_payslip_done

### DIFF
--- a/payroll_account/models/hr_payslip.py
+++ b/payroll_account/models/hr_payslip.py
@@ -83,7 +83,6 @@ class HrPayslip(models.Model):
                     continue
                 debit_account_id = line.salary_rule_id.account_debit.id
                 credit_account_id = line.salary_rule_id.account_credit.id
-                account_id = debit_account_id or credit_account_id
                 analytic_salary_id = line.salary_rule_id.analytic_account_id
                 move_line_analytic_ids = {}
                 if slip.contract_id.analytic_account_id:
@@ -94,79 +93,25 @@ class HrPayslip(models.Model):
                     move_line_analytic_ids.update(
                         {line.salary_rule_id.analytic_account_id.id: 100}
                     )
-
-                tax_ids = False
-                tax_tag_ids = False
-                if line.salary_rule_id.tax_line_ids:
-                    account_tax_ids = [
-                        salary_rule_id.account_tax_id.id
-                        for salary_rule_id in line.salary_rule_id.tax_line_ids
-                    ]
-                    tax_ids = [
-                        (4, account_tax_id, 0) for account_tax_id in account_tax_ids
-                    ]
-                    tax_tag_ids = (
-                        self.env["account.tax.repartition.line"]
-                        .search(
-                            [
-                                ("invoice_tax_id", "in", account_tax_ids),
-                                ("repartition_type", "=", "base"),
-                            ]
-                        )
-                        .tag_ids
-                    )
-
-                tax_repartition_line_id = False
-                if line.salary_rule_id.account_tax_id:
-                    tax_repartition_line_id = (
-                        self.env["account.tax.repartition.line"]
-                        .search(
-                            [
-                                (
-                                    "invoice_tax_id",
-                                    "=",
-                                    line.salary_rule_id.account_tax_id.id,
-                                ),
-                                ("account_id", "=", account_id),
-                            ]
-                        )
-                        .id
-                    )
-                    tax_tag_ids = (
-                        self.env["account.tax.repartition.line"]
-                        .search(
-                            [
-                                (
-                                    "invoice_tax_id",
-                                    "=",
-                                    line.salary_rule_id.account_tax_id.id,
-                                ),
-                                ("repartition_type", "=", "tax"),
-                                ("account_id", "=", account_id),
-                            ]
-                        )
-                        .tag_ids
-                    )
+                tax_ids, tax_tag_ids, tax_repartition_line_id = self._get_tax_details(
+                    line
+                )
 
                 if debit_account_id:
                     debit_line = (
                         0,
                         0,
-                        {
-                            "name": line.name,
-                            "partner_id": line._get_partner_id(credit_account=False)
-                            or slip.employee_id.address_home_id.id,
-                            "account_id": debit_account_id,
-                            "journal_id": slip.journal_id.id,
-                            "date": date,
-                            "debit": amount > 0.0 and amount or 0.0,
-                            "credit": amount < 0.0 and -amount or 0.0,
-                            "analytic_distribution": move_line_analytic_ids,
-                            "tax_line_id": line.salary_rule_id.account_tax_id.id,
-                            "tax_ids": tax_ids,
-                            "tax_repartition_line_id": tax_repartition_line_id,
-                            "tax_tag_ids": tax_tag_ids,
-                        },
+                        self._prepare_debit_line(
+                            line,
+                            slip,
+                            amount,
+                            date,
+                            debit_account_id,
+                            move_line_analytic_ids,
+                            tax_ids,
+                            tax_tag_ids,
+                            tax_repartition_line_id,
+                        ),
                     )
                     line_ids.append(debit_line)
                     debit_sum += debit_line[2]["debit"] - debit_line[2]["credit"]
@@ -175,21 +120,17 @@ class HrPayslip(models.Model):
                     credit_line = (
                         0,
                         0,
-                        {
-                            "name": line.name,
-                            "partner_id": line._get_partner_id(credit_account=True)
-                            or slip.employee_id.address_home_id.id,
-                            "account_id": credit_account_id,
-                            "journal_id": slip.journal_id.id,
-                            "date": date,
-                            "debit": amount < 0.0 and -amount or 0.0,
-                            "credit": amount > 0.0 and amount or 0.0,
-                            "analytic_distribution": move_line_analytic_ids,
-                            "tax_line_id": line.salary_rule_id.account_tax_id.id,
-                            "tax_ids": tax_ids,
-                            "tax_repartition_line_id": tax_repartition_line_id,
-                            "tax_tag_ids": tax_tag_ids,
-                        },
+                        self._prepare_credit_line(
+                            line,
+                            slip,
+                            amount,
+                            date,
+                            credit_account_id,
+                            move_line_analytic_ids,
+                            tax_ids,
+                            tax_tag_ids,
+                            tax_repartition_line_id,
+                        ),
                     )
                     line_ids.append(credit_line)
                     credit_sum += credit_line[2]["credit"] - credit_line[2]["debit"]
@@ -207,15 +148,9 @@ class HrPayslip(models.Model):
                 adjust_credit = (
                     0,
                     0,
-                    {
-                        "name": _("Adjustment Entry"),
-                        "partner_id": False,
-                        "account_id": acc_id,
-                        "journal_id": slip.journal_id.id,
-                        "date": date,
-                        "debit": 0.0,
-                        "credit": currency.round(debit_sum - credit_sum),
-                    },
+                    self._prepare_adjust_credit_line(
+                        currency, credit_sum, debit_sum, slip.journal_id, date
+                    ),
                 )
                 line_ids.append(adjust_credit)
 
@@ -232,15 +167,9 @@ class HrPayslip(models.Model):
                 adjust_debit = (
                     0,
                     0,
-                    {
-                        "name": _("Adjustment Entry"),
-                        "partner_id": False,
-                        "account_id": acc_id,
-                        "journal_id": slip.journal_id.id,
-                        "date": date,
-                        "debit": currency.round(credit_sum - debit_sum),
-                        "credit": 0.0,
-                    },
+                    self._prepare_adjust_debit_line(
+                        currency, credit_sum, debit_sum, slip.journal_id, date
+                    ),
                 )
                 line_ids.append(adjust_debit)
             if len(line_ids) > 0:
@@ -261,7 +190,7 @@ class HrPayslip(models.Model):
         amount,
         date,
         debit_account_id,
-        analytic_salary_id,
+        move_line_analytic_ids,
         tax_ids,
         tax_tag_ids,
         tax_repartition_line_id,
@@ -275,8 +204,7 @@ class HrPayslip(models.Model):
             "date": date,
             "debit": amount > 0.0 and amount or 0.0,
             "credit": amount < 0.0 and -amount or 0.0,
-            "analytic_account_id": analytic_salary_id
-            or slip.contract_id.analytic_account_id.id,
+            "analytic_distribution": move_line_analytic_ids,
             "tax_line_id": line.salary_rule_id.account_tax_id.id,
             "tax_ids": tax_ids,
             "tax_repartition_line_id": tax_repartition_line_id,
@@ -290,7 +218,7 @@ class HrPayslip(models.Model):
         amount,
         date,
         credit_account_id,
-        analytic_salary_id,
+        move_line_analytic_ids,
         tax_ids,
         tax_tag_ids,
         tax_repartition_line_id,
@@ -304,8 +232,7 @@ class HrPayslip(models.Model):
             "date": date,
             "debit": amount < 0.0 and -amount or 0.0,
             "credit": amount > 0.0 and amount or 0.0,
-            "analytic_account_id": analytic_salary_id
-            or slip.contract_id.analytic_account_id.id,
+            "analytic_distribution": move_line_analytic_ids,
             "tax_line_id": line.salary_rule_id.account_tax_id.id,
             "tax_ids": tax_ids,
             "tax_repartition_line_id": tax_repartition_line_id,


### PR DESCRIPTION
Different `_prepare_*` methods were added to this module in #158 but they weren't used in the action_payslip_done method.