### PR TITLE
[16.0][IMP] payroll_contract_advantages: set currency_id in contract advantage templates

### DIFF
--- a/payroll_contract_advantages/models/hr_contract_advantage.py
+++ b/payroll_contract_advantages/models/hr_contract_advantage.py
@@ -15,13 +15,16 @@ class HrContractAdvantage(models.Model):
     advantage_template_code = fields.Char(
         string="Code", related="advantage_template_id.code", readonly=True
     )
-    advantage_lower_bound = fields.Float(
+    currency_id = fields.Many2one(
+        related="contract_id.currency_id", store=True, readonly=True
+    )
+    advantage_lower_bound = fields.Monetary(
         string="Lower Bound", related="advantage_template_id.lower_bound", readonly=True
     )
-    advantage_upper_bound = fields.Float(
+    advantage_upper_bound = fields.Monetary(
         string="Upper Bound", related="advantage_template_id.upper_bound", readonly=True
     )
-    amount = fields.Float()
+    amount = fields.Monetary(currency_field="currency_id")
 
     @api.onchange("advantage_template_id")
     def _onchange_advantage_template_id(self):

--- a/payroll_contract_advantages/models/hr_contract_advantage_template.py
+++ b/payroll_contract_advantages/models/hr_contract_advantage_template.py
@@ -9,10 +9,18 @@ class HrContractAdvandageTemplate(models.Model):
 
     name = fields.Char(required=True)
     code = fields.Char(required=True)
-    lower_bound = fields.Float(
-        help="Lower bound authorized by the employer for this advantage"
+    currency_id = fields.Many2one(
+        "res.currency",
+        required=True,
+        default=lambda self: self.env.company.currency_id,
     )
-    upper_bound = fields.Float(
-        help="Upper bound authorized by the employer for this advantage"
+
+    lower_bound = fields.Monetary(
+        currency_field="currency_id",
+        help="Lower bound authorized by the employer for this advantage",
     )
-    default_value = fields.Float()
+    upper_bound = fields.Monetary(
+        currency_field="currency_id",
+        help="Upper bound authorized by the employer for this advantage",
+    )
+    default_value = fields.Monetary(currency_field="currency_id")

--- a/payroll_contract_advantages/views/hr_contract_advantage_views.xml
+++ b/payroll_contract_advantages/views/hr_contract_advantage_views.xml
@@ -21,6 +21,7 @@
                             <field name="default_value" />
                             <field name="lower_bound" />
                             <field name="upper_bound" />
+                            <field name="currency_id" invisible="1" />
                         </group>
                     </group>
                 </sheet>

--- a/payroll_contract_advantages/views/hr_contract_views.xml
+++ b/payroll_contract_advantages/views/hr_contract_views.xml
@@ -17,6 +17,7 @@
                         <field name="advantage_lower_bound" />
                         <field name="advantage_upper_bound" />
                         <field name="amount" />
+                        <field name="currency_id" invisible="1" />
                     </tree>
                 </field>
             </xpath>


### PR DESCRIPTION
## Problem

The contract advantage templates did not display the correct currency in monetary fields because the model had no currency_id field defined.

cc @nimarosa