### PR TITLE
[16.0][FIX] payroll_contract_advantages: enforce unique advantage template per contract

### DIFF
--- a/payroll_contract_advantages/models/hr_contract_advantage.py
+++ b/payroll_contract_advantages/models/hr_contract_advantage.py
@@ -43,3 +43,11 @@ class HrContractAdvantage(models.Model):
                     raise ValidationError(
                         _("Advantage amount can't be less than lower bound limit.")
                     )
+
+    _sql_constraints = [
+        (
+            "uniq_contract_template",
+            "unique(contract_id, advantage_template_id)",
+            "This advantage template is already set on this contract.",
+        ),
+    ]


### PR DESCRIPTION
## Problem

The model `hr.contract.advantage` allowed duplicate records with the same `contract_id` and `advantage_template_id`

cc @kaynnan @marcelsavegnago @WesleyOliveira98 