### PR TITLE
[16.0][REF] payroll: report amount != 0

### DIFF
--- a/payroll/views/report_payslip.xml
+++ b/payroll/views/report_payslip.xml
@@ -89,7 +89,7 @@
                             </thead>
                             <tbody>
                                 <tr
-                                    t-foreach="o.line_ids.filtered(lambda line: line.appears_on_payslip)"
+                                    t-foreach="o.line_ids.filtered(lambda l: l.appears_on_payslip and l.amount != 0)"
                                     t-as="line"
                                 >
                                     <td>


### PR DESCRIPTION
## Description
By default, the payslip report prints all salary lines, even if their amounts are zero. With this change, only rules that actually generate a value for the employee (e.g., salary, bonus, overtime, deductions) are displayed.

#### Why is this useful?

Keeps the report cleaner and easier to read.

Avoids confusion by hiding unused or zero-amount salary rules.

Highlights only the relevant values for the employee in a given period.

cc @kaynnan @marcelsavegnago @WesleyOliveira98 