### PR TITLE
[15.0][IMP] hr_payroll_period: add a company parameter to select the months in advance for creating the new HR periods 

### DIFF
--- a/hr_payroll_period/README.rst
+++ b/hr_payroll_period/README.rst
@@ -54,6 +54,10 @@ Configuration
 
 Create a fiscal year
 ~~~~~~~~~~~~~~~~~~~~
+
+Go to: Payroll -> Configuration -> Settings -> Payroll
+ - Put the number of months in advance for creating the new HR periods
+
 Go to: Payroll -> Configuration -> Payroll Fiscal Year
 
  - Select a type of schedule, e.g. monthly

--- a/hr_payroll_period/__manifest__.py
+++ b/hr_payroll_period/__manifest__.py
@@ -27,6 +27,7 @@
         "views/hr_payslip_view.xml",
         "views/hr_payslip_run_view.xml",
         "views/hr_payslip_employee_view.xml",
+        "views/res_config_settings_view.xml",
     ],
     "installable": True,
     "maintainers": ["nimarosa"],

--- a/hr_payroll_period/data/ir_cron.xml
+++ b/hr_payroll_period/data/ir_cron.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <odoo noupdate="1">
     <record id="ir_cron_hr_payroll_period" model="ir.cron">
-        <field name='name'>Create Next Fiscal Year</field>
+        <field name='name'>Create Next Payroll Fiscal Year</field>
         <field name='interval_number'>1</field>
         <field name='interval_type'>months</field>
         <field name="numbercall">-1</field>

--- a/hr_payroll_period/models/__init__.py
+++ b/hr_payroll_period/models/__init__.py
@@ -8,3 +8,5 @@ from . import hr_payslip_employees
 from . import hr_payslip_run
 from . import hr_period
 from . import hr_employee
+from . import res_company
+from . import res_config_settings

--- a/hr_payroll_period/models/hr_fiscal_year.py
+++ b/hr_payroll_period/models/hr_fiscal_year.py
@@ -305,44 +305,45 @@ class HrFiscalYear(models.Model):
 
     @api.model
     def cron_create_next_fiscal_year(self):
-        current_year = datetime.now().year
+        company = self.env.company
+        today = fields.Date.context_today(self)
+        current_year = today.year
         next_year = current_year + 1
-        # Get the latest fiscal year that has not ended yet
-        latest_fiscal_year = self.search(
-            [("date_end", "<", datetime(next_year, 1, 1).strftime(DF))],
-            order="date_end desc",
+        current_fy = self.search(
+            [("date_start", "<=", today), ("date_end", ">=", today)],
             limit=1,
         )
-        if not latest_fiscal_year:
+        if not current_fy:
             return self
-        latest_period_end = max(latest_fiscal_year.period_ids.mapped("date_end"))
-        fiscal_year_start = latest_period_end + relativedelta(days=1)
+
+        threshold_date = fields.Date.from_string(current_fy.date_end) - relativedelta(
+            months=company.payroll_fiscalyear_creation_months_before
+        )
+        if today < threshold_date:
+            return self
+        fiscal_year_start = fields.Date.from_string(
+            current_fy.date_end
+        ) + relativedelta(days=1)
         fiscal_year_end = datetime(next_year, 12, 31).strftime(DF)
-        # Check if a fiscal year with the same start and end dates already exists
-        existing_fiscal_year = self.search(
+        existing_fy = self.search(
             [
                 ("date_start", "=", fiscal_year_start),
                 ("date_end", "=", fiscal_year_end),
             ],
             limit=1,
         )
-        if existing_fiscal_year:
-            return existing_fiscal_year
-
-        schedule_pay = latest_fiscal_year.schedule_pay
-        payment_weekday = latest_fiscal_year.payment_weekday
-        payment_week = latest_fiscal_year.payment_week
+        if existing_fy:
+            return existing_fy
+        schedule_pay = current_fy.schedule_pay
+        payment_weekday = current_fy.payment_weekday
+        payment_week = current_fy.payment_week
         schedule_name = next(
             (s[1] for s in get_schedules(self) if s[0] == schedule_pay), False
         )
-
         fiscal_year = self.create(
             {
                 "name": "%(year)s - %(schedule)s"
-                % {
-                    "year": next_year,
-                    "schedule": schedule_name,
-                },
+                % {"year": next_year, "schedule": schedule_name},
                 "date_start": fiscal_year_start,
                 "date_end": fiscal_year_end,
                 "schedule_pay": schedule_pay,

--- a/hr_payroll_period/models/res_company.py
+++ b/hr_payroll_period/models/res_company.py
@@ -1,0 +1,26 @@
+from odoo import _, api, fields, models
+from odoo.exceptions import ValidationError
+
+
+class ResCompany(models.Model):
+    _inherit = "res.company"
+
+    payroll_fiscalyear_creation_months_before = fields.Integer(
+        string="Months Before HR Fiscal Year Creation",
+        default=1,
+        help="How many months before the end of the HR fiscal year "
+        "a new one should be created.",
+    )
+
+    @api.constrains("payroll_fiscalyear_creation_months_before")
+    def _check_fiscalyear_creation_months_before(self):
+        for company in self:
+            if (
+                company.payroll_fiscalyear_creation_months_before < 0
+                or company.payroll_fiscalyear_creation_months_before > 12
+            ):
+                raise ValidationError(
+                    _(
+                        "Payroll fiscal year creation months before must be between 0 and 12."
+                    )
+                )

--- a/hr_payroll_period/models/res_config_settings.py
+++ b/hr_payroll_period/models/res_config_settings.py
@@ -1,0 +1,10 @@
+from odoo import fields, models
+
+
+class ResConfigSettings(models.TransientModel):
+    _inherit = "res.config.settings"
+
+    payroll_fiscalyear_creation_months_before = fields.Integer(
+        related="company_id.payroll_fiscalyear_creation_months_before",
+        readonly=False,
+    )

--- a/hr_payroll_period/readme/CONFIGURE.rst
+++ b/hr_payroll_period/readme/CONFIGURE.rst
@@ -1,5 +1,9 @@
 Create a fiscal year
 ~~~~~~~~~~~~~~~~~~~~
+
+Go to: Payroll -> Configuration -> Settings -> Payroll
+ - Put the number of months in advance for creating the new HR periods
+
 Go to: Payroll -> Configuration -> Payroll Fiscal Year
 
  - Select a type of schedule, e.g. monthly

--- a/hr_payroll_period/static/description/index.html
+++ b/hr_payroll_period/static/description/index.html
@@ -408,6 +408,13 @@ batch name and the company on the payslip batch.</p>
 <h1><a class="toc-backref" href="#toc-entry-2">Configuration</a></h1>
 <div class="section" id="create-a-fiscal-year">
 <h2><a class="toc-backref" href="#toc-entry-3">Create a fiscal year</a></h2>
+<dl class="docutils">
+<dt>Go to: Payroll -&gt; Configuration -&gt; Settings -&gt; Payroll</dt>
+<dd><ul class="first last simple">
+<li>Put the number of months in advance for creating the new HR periods</li>
+</ul>
+</dd>
+</dl>
 <p>Go to: Payroll -&gt; Configuration -&gt; Payroll Fiscal Year</p>
 <blockquote>
 <ul class="simple">

--- a/hr_payroll_period/tests/test_hr_fiscalyear.py
+++ b/hr_payroll_period/tests/test_hr_fiscalyear.py
@@ -349,6 +349,7 @@ class TestHrFiscalyear(common.TransactionCase):
 
     def test_cron_create_next_fiscal_year(self):
         # if we are in 2024, it should create the periods for 2025
+        self.env.company.payroll_fiscalyear_creation_months_before = 12
         current_year = datetime.now().year
         current_fiscal_year = self.fy_model.search(
             [

--- a/hr_payroll_period/views/res_config_settings_view.xml
+++ b/hr_payroll_period/views/res_config_settings_view.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="res_config_settings_view_form_inherit_fiscalyear" model="ir.ui.view">
+        <field name="name">res.config.settings.view.form.inherit.fiscalyear</field>
+        <field name="model">res.config.settings</field>
+        <field name="priority" eval="50" />
+        <field name="inherit_id" ref="payroll.res_config_settings_view_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//div[@data-key='payroll']" position="inside">
+                <h2>Payroll Fiscal Year Periods Automation</h2>
+                <div
+                    class="row mt16 o_settings_container"
+                    name="period_automatyion_settings_container"
+                >
+                    <div class="col-12 col-lg-6 o_setting_box">
+                        <div class="o_setting_right_pane">
+                            <label for="payroll_fiscalyear_creation_months_before" />
+                            <span
+                                class="fa fa-lg fa-building-o"
+                                title="Values set here are company-specific."
+                                groups="base.group_multi_company"
+                            />
+                            <div class="row">
+                                <div class="text-muted col-lg-8">
+                                    Number of months before year end to automatically create the Payroll next fiscal year.
+                                    <br />Default = 1 (December 1st).
+                                </div>
+                            </div>
+                            <div class="content-group mt16">
+                                <field
+                                    name="payroll_fiscalyear_creation_months_before"
+                                    widget="integer"
+                                />
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </xpath>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
Currently users cannot select how much in advance the periods are created.

<img width="429" height="222" alt="image" src="https://github.com/user-attachments/assets/c81b9cee-1df8-4e93-b14b-942336fb9ee5" />

I can put days instead of months... 
