### PR TITLE
[18.0][FIX] payroll_account: Fix _get_partner_id logic in hr_payslip_line

### DIFF
--- a/payroll_account/__manifest__.py
+++ b/payroll_account/__manifest__.py
@@ -1,7 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 {
     "name": "Payroll Accounting",
-    "version": "18.0.1.0.4",
+    "version": "18.0.1.0.5",
     "category": "Payroll",
     "website": "https://github.com/OCA/payroll",
     "license": "LGPL-3",

--- a/payroll_account/models/hr_payslip_line.py
+++ b/payroll_account/models/hr_payslip_line.py
@@ -10,12 +10,53 @@ class HrPayslipLine(models.Model):
     def _get_partner_id(self, credit_account):
         """
         Get partner_id of slip line to use in account_move_line
+
+        Partner is required only for specific account types that track external
+        relationships:
+        - asset_receivable: Employee loans, salary advances, overpayments to recover
+                           → Partner source: Employee (work_contact_id or
+                             bank_account_id.partner_id)
+        - liability_payable: Third-party payables (tax authorities, insurance
+                            companies) typically managed through contribution
+                            registers
+                           → Partner source: Register partner
+                             (salary_rule_id.register_id.partner_id)
+        - liability_current: Current liabilities to pay employee salaries, net pay
+                            accruals
+                           → Partner source: Employee (work_contact_id or
+                             bank_account_id.partner_id)
+
+        For other account types (expense, income, asset_current, etc.), no partner
+        is assigned as these represent internal accounting entries without external
+        party relationships.
         """
-        # use partner of salary rule or fallback on employee's address
-        register_partner_id = self.salary_rule_id.register_id.partner_id
-        acc_type = self.salary_rule_id.account_debit.account_type
-        if credit_account:
-            acc_type = self.salary_rule_id.account_credit.account_type
-        if register_partner_id or acc_type in ("asset_receivable", "liability_payable"):
-            return register_partner_id.id
+        # Determine which account we're dealing with
+        acc_type = (
+            self.salary_rule_id.account_credit.account_type
+            if credit_account
+            else self.salary_rule_id.account_debit.account_type
+        )
+
+        if acc_type in ("asset_receivable", "liability_current"):
+            # Employee-related accounts - always employee
+            return (
+                self.slip_id.employee_id.work_contact_id.id
+                if self.slip_id.employee_id.work_contact_id
+                else (
+                    self.slip_id.employee_id.bank_account_id.partner_id.id
+                    if self.slip_id.employee_id.bank_account_id
+                    else False
+                )
+            )
+
+        elif acc_type == "liability_payable":
+            # Third-party payables - always register partner
+            return (
+                self.salary_rule_id.register_id.partner_id.id
+                if self.salary_rule_id.register_id
+                and self.salary_rule_id.register_id.partner_id
+                else False
+            )
+
+        # All other account types (expense, income, etc.)
         return False

--- a/payroll_account/tests/test_payroll_account.py
+++ b/payroll_account/tests/test_payroll_account.py
@@ -183,3 +183,39 @@ class TestPayrollAccount(common.TransactionCase):
 
         # I verify that the payslip is in done state.
         self.assertEqual(self.hr_payslip.state, "done", "State not changed!")
+
+    def test_partner_logic_account_types(self):
+        """Test partner logic for different account types."""
+        # Employee already has work_contact_id auto-created
+        employee_partner = self.hr_employee_john.work_contact_id
+
+        # Create register with different partner
+        register_partner = self.env["res.partner"].create({"name": "Tax Authority"})
+        register = self.env["hr.contribution.register"].create(
+            {"name": "Tax Register", "partner_id": register_partner.id}
+        )
+
+        # Create rule and payslip line
+        rule = self.env.ref("payroll.hr_salary_rule_houserentallowance1")
+        rule.register_id = register
+        payslip = self._prepare_payslip(self.hr_employee_john)
+        line = self.env["hr.payslip.line"].create(
+            {"slip_id": payslip.id, "salary_rule_id": rule.id, "name": "Test"}
+        )
+
+        # Test asset_receivable -> employee partner
+        self.account_credit.account_type = "asset_receivable"
+        rule.account_credit = self.account_credit
+        self.assertEqual(line._get_partner_id(True), employee_partner.id)
+
+        # Test liability_current -> employee partner
+        self.account_credit.account_type = "liability_current"
+        self.assertEqual(line._get_partner_id(True), employee_partner.id)
+
+        # Test liability_payable -> register partner
+        self.account_credit.account_type = "liability_payable"
+        self.assertEqual(line._get_partner_id(True), register_partner.id)
+
+        # Test other account types -> no partner
+        self.account_credit.account_type = "expense"
+        self.assertFalse(line._get_partner_id(True))


### PR DESCRIPTION
## Description
This PR fixes the partner logic in `hr_payslip_line._get_partner_id()` to address issue #221 where journal entries were created without proper partner information in Odoo 17.0+.

## Problem
The original logic had several issues:

1. Odoo removed field `address_home_id` from model `hr.employee` which was used in getting partner for employee in `payroll_account` to set partner in created journal entry. Migrated code removed usage of `address_home_id` but did not use a replacement.
2. Old code (16.0 and earlier) used a confusing fallback chain that could potentially assign wrong partners
3. Missing `liability_current` account type in partner-required accounts

## Solution
Replaced the flawed logic with semantically-correct partner assignment using the proper partner source:

- **asset_receivable & liability_current**: Always use employee partner (work_contact_id → bank_account_id.partner_id)
- **liability_payable**: Always use register partner (salary_rule_id.register_id.partner_id)
- **Other account types** (expense, income, etc.): No partner assigned

## Changes

### Core Logic (payroll_account/models/hr_payslip_line.py)

- Simplified logic from confusing fallback to clear semantic rules
- Added liability_current to partner-required account types
- Enhanced documentation with business semantics and partner sources
- Replaced if register_partner_id or acc_type in (...) with proper if elif structure

### Business Logic

| Account Type | Business Use | Partner Source |
|---|---|---|
| asset_receivable | Employee loans, advances | Employee |
| liability_current | Employee salary payable | Employee |
| liability_payable | Tax authorities, insurance | Register Partner |
| expense, income, etc. | Internal accounting | No Partner |

### Test Coverage

Added `test_partner_logic_account_types()` to verify:
- asset_receivable accounts return employee partner
- liability_current accounts return employee partner
- liability_payable accounts return register partner
- Other account types return False (no partner)

Fixes #221

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author