### PR TITLE
[16.0][FIX] payroll: Fix warnings for "digits" parameter

### DIFF
--- a/payroll/models/hr_payslip_line.py
+++ b/payroll/models/hr_payslip_line.py
@@ -47,6 +47,9 @@ class HrPayslipLine(models.Model):
         "Allow editing", compute="_compute_allow_edit_payslip_lines"
     )
 
+    def _valid_field_parameter(self, field, name):
+        return name == "digits" or super()._valid_field_parameter(field, name)
+
     def _compute_allow_edit_payslip_lines(self):
         self.allow_edit_payslip_lines = (
             self.env["ir.config_parameter"]


### PR DESCRIPTION
   Warnings generated from "hr.payslip.line" model for "digits" parameter is addressed.
   
   Below is the warning seen:
   2025-11-07 10:01:16,587 21 WARNING devel odoo.fields: Field hr.payslip.line.amount: unknown parameter 'digits', if this is an actual parameter you may want to override the method _valid_field_parameter on the relevant model in order to allow it 