### PR TITLE
[17.0][FIX] payroll: make payslip name editable again at draft state

### DIFF
--- a/payroll/models/hr_payslip.py
+++ b/payroll/models/hr_payslip.py
@@ -39,7 +39,7 @@ class HrPayslip(models.Model):
         "applied will be all the rules set on the structure of all contracts "
         "of the employee valid for the chosen period",
     )
-    name = fields.Char(string="Payslip Name", readonly=True)
+    name = fields.Char(string="Payslip Name")
     number = fields.Char(
         string="Reference",
         readonly=True,

--- a/payroll/views/hr_payslip_views.xml
+++ b/payroll/views/hr_payslip_views.xml
@@ -143,7 +143,7 @@
                     </div>
                     <div class="oe_title">
                         <h1>
-                            <field name="name" force_save="1" />
+                            <field name="name" readonly="state != 'draft'" />
                         </h1>
                     </div>
                     <group col="4">


### PR DESCRIPTION
Prior to v17 that was default behavior, this restores it.

I've looked at https://github.com/OCA/payroll/pull/142 and I've didn't find any explanation of such change.

@hapolinario @dreispt could you review? Thanks!! If merged, I'll port it to v18.

cc @lmiguens-solvos 