### PR TITLE
[FIX] hr_payroll_document: Allow to view Employee after wizard

### DIFF
--- a/hr_payroll_document/README.rst
+++ b/hr_payroll_document/README.rst
@@ -58,6 +58,9 @@ Contributors
 
 * Antoni Marroig Campomar <amarroig@apsl.net>
 * Miquel Alzanillas Monserrat <malzanillas@apsl.net>
+* `PyTech <https://www.pytech.it>`_:
+
+  * Simone Rubino <simone.rubino@pytech.it>
 
 Maintainers
 ~~~~~~~~~~~

--- a/hr_payroll_document/readme/CONTRIBUTORS.rst
+++ b/hr_payroll_document/readme/CONTRIBUTORS.rst
@@ -1,2 +1,5 @@
 * Antoni Marroig Campomar <amarroig@apsl.net>
 * Miquel Alzanillas Monserrat <malzanillas@apsl.net>
+* `PyTech <https://www.pytech.it>`_:
+
+  * Simone Rubino <simone.rubino@pytech.it>

--- a/hr_payroll_document/static/description/index.html
+++ b/hr_payroll_document/static/description/index.html
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
@@ -9,10 +8,11 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
+:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
+Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -275,7 +275,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: grey; } /* line numbers */
+pre.code .ln { color: gray; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -301,7 +301,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic {
+span.problematic, pre.problematic {
   color: red }
 
 span.section-subtitle {
@@ -404,12 +404,18 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <ul class="simple">
 <li>Antoni Marroig Campomar &lt;<a class="reference external" href="mailto:amarroig&#64;apsl.net">amarroig&#64;apsl.net</a>&gt;</li>
 <li>Miquel Alzanillas Monserrat &lt;<a class="reference external" href="mailto:malzanillas&#64;apsl.net">malzanillas&#64;apsl.net</a>&gt;</li>
+<li><a class="reference external" href="https://www.pytech.it">PyTech</a>:<ul>
+<li>Simone Rubino &lt;<a class="reference external" href="mailto:simone.rubino&#64;pytech.it">simone.rubino&#64;pytech.it</a>&gt;</li>
+</ul>
+</li>
 </ul>
 </div>
 <div class="section" id="maintainers">
 <h2><a class="toc-backref" href="#toc-entry-5">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
-<a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
+<a class="reference external image-reference" href="https://odoo-community.org">
+<img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />
+</a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>

--- a/hr_payroll_document/tests/test_hr_payroll_document.py
+++ b/hr_payroll_document/tests/test_hr_payroll_document.py
@@ -68,10 +68,10 @@ class TestHRPayrollDocument(TestHrPayrollDocument):
                         "type": "ir.actions.act_window",
                         "res_model": "hr.employee",
                         "views": [
-                            (
-                                self.env.ref("hr.hr_employee_public_view_kanban").id,
-                                "list",
-                            )
+                            (False, "kanban"),
+                            (False, "tree"),
+                            (False, "form"),
+                            (False, "activity"),
                         ],
                     },
                 },
@@ -96,10 +96,10 @@ class TestHRPayrollDocument(TestHrPayrollDocument):
                         "type": "ir.actions.act_window",
                         "res_model": "hr.employee",
                         "views": [
-                            (
-                                self.env.ref("hr.hr_employee_public_view_kanban").id,
-                                "list",
-                            )
+                            (False, "kanban"),
+                            (False, "tree"),
+                            (False, "form"),
+                            (False, "activity"),
                         ],
                     },
                 },

--- a/hr_payroll_document/wizard/payroll_management_wizard.py
+++ b/hr_payroll_document/wizard/payroll_management_wizard.py
@@ -79,10 +79,10 @@ class PayrollManagamentWizard(models.TransientModel):
                         "type": "ir.actions.act_window",
                         "res_model": "hr.employee",
                         "views": [
-                            (
-                                self.env.ref("hr.hr_employee_public_view_kanban").id,
-                                "list",
-                            )
+                            (False, "kanban"),
+                            (False, "tree"),
+                            (False, "form"),
+                            (False, "activity"),
                         ],
                     },
                 },
@@ -101,7 +101,10 @@ class PayrollManagamentWizard(models.TransientModel):
                     "type": "ir.actions.act_window",
                     "res_model": "hr.employee",
                     "views": [
-                        (self.env.ref("hr.hr_employee_public_view_kanban").id, "list")
+                        (False, "kanban"),
+                        (False, "tree"),
+                        (False, "form"),
+                        (False, "activity"),
                     ],
                 },
             },


### PR DESCRIPTION
Issue discovered in https://github.com/OCA/payroll/pull/236#discussion_r2635476669.

Steps:
1. Execute the Payrolls wizard
2. The kanban of employees is shown
3. Click on an Employee card

Before this change:
Nothing happens

After this change:
The Employee form is shown