### PR TITLE
[18.0][REF] payroll: refactor start/end dates the month

### DIFF
--- a/payroll/tests/test_payslip_flow.py
+++ b/payroll/tests/test_payslip_flow.py
@@ -223,14 +223,20 @@ class TestPayslipFlow(TestPayslipBase):
             len(contracts), 1, "There is one open contract for the employee"
         )
 
-        self.sally.contract_id.date_end = (Date.today() - timedelta(days=1)).strftime(
-            "%Y-%m-%d"
+        first_contract = self.sally.contract_id
+        end_date = first_contract.date_start
+        first_contract.write(
+            {
+                "date_end": end_date.strftime("%Y-%m-%d"),
+                "state": "close",
+            }
         )
+        second_start = end_date + timedelta(days=1)
         self.Contract.create(
             {
                 "name": "Second contract for Sally",
                 "employee_id": self.sally.id,
-                "date_start": Date.today().strftime("%Y-%m-%d"),
+                "date_start": second_start.strftime("%Y-%m-%d"),
                 "struct_id": self.sales_pay_structure.id,
                 "wage": 6500.00,
                 "state": "open",


### PR DESCRIPTION

## Root cause
The failing test was TestPayslipFlow.test_get_contracts_singleton in payroll/tests/test_payslip_flow.py.
This test was tweaking dates and creating a second contract for employee Sally using `Date.today()`, assuming that would always be safe.
In the current hr_contract implementation, there is a constraint` (_check_current_contract)` that forbids an employee from having two overlapping contracts in active-like states (incoming/open/close), except when they are draft or cancel.
Combined with the way Sally’s first contract is created in `common.py` (always starting on the first day of the month), this meant that around certain dates (especially month/year boundaries) the two contracts’ periods could overlap, triggering:
ValidationError: An employee can only have one contract at the same time. (Excluding Draft and Cancelled contracts).
#### Fix
Instead of relying on `Date.today()` inside the test, we now build the scenario based on the actual dates of Sally’s first contract, which is created in TestPayslipBase:
Retrieve Sally’s current contract: `first_contract = self.sally.contract_id.`
Close that contract with a non-overlapping, valid period:
`date_end = first_contract.date_start`
`first_contract.write({"date_end": end_date.strftime("%Y-%m-%d"), "state": "close"})`
Create the second contract starting the day after the first contract ends:
`second_start = end_date + timedelta(days=1)`
`self.Contract.create({... "date_start": second_start.strftime("%Y-%m-%d"), ...})`
#### With this:
There is no longer any overlap between Sally’s contracts.
The _check_current_contract constraint is satisfied.
The test still verifies the intended behavior —` _get_employee_contracts()` returns exactly one valid contract for the employee — but now in a deterministic, date‑independent way.