### PR TITLE
[FIX] hr_payroll_document: Do not fetch optional encryption

### DIFF
--- a/hr_payroll_document/models/hr_employee.py
+++ b/hr_payroll_document/models/hr_employee.py
@@ -14,6 +14,7 @@ class Employee(models.Model):
         "the PDF payrolls are encrypted using the Identification No.\n"
         "Only future payrolls are affected by this change, "
         "existing payrolls will not change their encryption status.",
+        groups="hr.group_hr_user",
     )
 
     def _validate_payroll_identification(self, code=None):

--- a/hr_payroll_document/tests/test_hr_payroll_document.py
+++ b/hr_payroll_document/tests/test_hr_payroll_document.py
@@ -120,3 +120,18 @@ class TestHRPayrollDocument(TestHrPayrollDocument):
         payroll_content = base64.b64decode(payroll.datas)
         payroll_pdf = pypdf.PdfReader(io.BytesIO(payroll_content))
         self.assertFalse(payroll_pdf.is_encrypted)
+
+    def test_optional_encryption_fetch(self):
+        """If the user can't access the employees,
+        the optional encryption field is not fetched."""
+        # Arrange
+        employee = self.employee_emp
+        employee_with_self = employee.with_user(employee.user_id)
+        # pre-condition
+        self.assertFalse(
+            employee_with_self.check_access_rights("read", raise_exception=False)
+        )
+
+        # Assert: reading a field triggers fetching all the accessible fields
+        employee_with_self.invalidate_recordset()
+        self.assertTrue(employee_with_self.user_id)


### PR DESCRIPTION
**Steps**:
1. Install Expenses (`hr_expense`)
2. In an employee: Action > Create User
3. Remove all HR groups from the created user: <img width="248" height="154" alt="image" src="https://github.com/user-attachments/assets/000f293f-765c-419b-8b9e-947631fde951" />
4. Login as the created user
5. Open Expenses > My Expenses > My Reports
6. Create a new report
7. Save

**Before this change**:
An Exception is raised:
> ValueError: Invalid field 'no_payroll_encryption' on model 'hr.employee.public'

<details><summary>Stack trace</summary>
<pre>
[...]
  File "/opt/odoo/auto/addons/hr_expense/models/hr_expense.py", line 1080, in _compute_can_reset
    sheet.can_reset = is_expense_user if is_expense_user else sheet.employee_id.user_id == self.env.user
  File "/opt/odoo/custom/src/odoo/odoo/fields.py", line 2824, in __get__
    return super().__get__(records, owner)
  File "/opt/odoo/custom/src/odoo/odoo/fields.py", line 1187, in __get__
    recs._fetch_field(self)
  File "/opt/odoo/custom/src/odoo/odoo/models.py", line 3245, in _fetch_field
    self._read(fnames)
  File "/opt/odoo/auto/addons/hr/models/hr_employee.py", line 203, in _read
    public.read(fields)
  File "/opt/odoo/custom/src/odoo/odoo/models.py", line 3027, in read
    raise ValueError("Invalid field %r on model %r" % (name, self._name))
ValueError: Invalid field 'no_payroll_encryption' on model 'hr.employee.public'
</pre>
</details> 

**After this change**:
The report is saved

**Additional context**:
Setting the `groups` in the field is actually the recommended configuration for fields that are not in `hr.employee.public`:
>  NB: Any field only available on the model hr.employee (i.e. not on the
    hr.employee.public model) should have `groups="hr.group_hr_user"` on its
    definition to avoid being prefetched when the user hasn't access to the
    hr.employee model. Indeed, the prefetch loads the data for all the fields
    that are available according to the group defined on them.

(from https://github.com/odoo/odoo/blob/17046990335b2f53d04fa829dfe1493e4f149d93/addons/hr/models/hr_employee.py#L20-L26)