### PR TITLE
[18.0][FIX] payroll_hr_public_holidays: wrong related field to get partner corresponding to employee

### DIFF
--- a/payroll_hr_public_holidays/models/hr_payslip.py
+++ b/payroll_hr_public_holidays/models/hr_payslip.py
@@ -29,7 +29,8 @@ class HrPayslip(models.Model):
             year=date_from.year,
             start_dt=date_from,
             end_dt=date_to,
-            partner_id=contract.employee_id.message_partner_ids.id,
+            partner_id=contract.employee_id.user_id.partner_id.id
+            or contract.employee_id.work_contact_id.id,
         )
         ph_days = len(public_holidays)
         ph_hours = (


### PR DESCRIPTION
Fixes the behaviour that was getting followers of the employee instead of the related partner

Steps to reproduce the issue : 
- add several followers to an employee
- calculate a draft payslip

raise ValueError("Expected singleton: %s" % record)
ValueError: Expected singleton: res.partner(....)
