### PR TITLE
[19.0][FIX] payroll: add security group to payroll fields on hr.version and hr.employee

### DIFF
--- a/payroll/models/hr_contract.py
+++ b/payroll/models/hr_contract.py
@@ -12,7 +12,11 @@ class HrContract(models.Model):
     _inherit = "hr.version"
     _description = "Employee Contract / Version"
 
-    struct_id = fields.Many2one("hr.payroll.structure", string="Salary Structure")
+    struct_id = fields.Many2one(
+        "hr.payroll.structure",
+        string="Salary Structure",
+        groups="payroll.group_payroll_user",
+    )
     schedule_pay = fields.Selection(
         [
             ("monthly", "Monthly"),
@@ -27,6 +31,7 @@ class HrContract(models.Model):
         index=True,
         default="monthly",
         help="Defines the frequency of the wage payment.",
+        groups="payroll.group_payroll_user",
     )
     resource_calendar_id = fields.Many2one(help="Employee's working schedule.")
 

--- a/payroll/models/hr_employee.py
+++ b/payroll/models/hr_employee.py
@@ -8,7 +8,11 @@ class HrEmployee(models.Model):
     _description = "Employee"
 
     slip_ids = fields.One2many(
-        "hr.payslip", "employee_id", string="Payslips", readonly=True
+        "hr.payslip",
+        "employee_id",
+        string="Payslips",
+        readonly=True,
+        groups="payroll.group_payroll_user",
     )
     payslip_count = fields.Integer(
         compute="_compute_payslip_count",


### PR DESCRIPTION
## Problem

Odoo 19 hardened HR field visibility. `hr.version` and `hr.employee` are now expected to declare a
security group on payroll-sensitive fields, and core ships tests that enforce it
(`hr.tests.test_payroll_fields_access`, `hr.tests.test_self_user_access`).

This module declares `groups` on `payslip_count` only. `struct_id`, `schedule_pay` and `slip_ids`
have none, so the salary structure and the payslip list are readable by any HR user and leak into
employee public profiles:

```
AccessError: The fields "slip_ids,struct_id,schedule_pay", which you are trying to read,
are not available for employee public profiles.
```

## How to reproduce

On a fresh database with `odoo:19.0` (Community):

```bash
odoo -d <db> -i payroll --test-enable --stop-after-init
```

Before this change: **3 failed, 1 error of 1087 tests**

```
FAIL: TestPayrollFieldsAccess.test_payroll_fields_are_hidden_to_non_payroll_users_in_employee_form_view
  AssertionError: ['struct_id'] is not false : [hr.employee] Missing payroll group on following fields
FAIL: TestPayrollFieldsAccess.test_payroll_fields_are_hidden_to_non_payroll_users_in_version_form_view
  AssertionError: ['schedule_pay', 'struct_id'] is not false : [hr.version] Missing payroll group on following fields
ERROR: TestSelfAccessPreferences.test_employee_fields_groups
  odoo.exceptions.AccessError: The fields "slip_ids,struct_id,schedule_pay" ... not available for employee public profiles
```

(The fourth failure, `calendar.test_event_notifications.test_email_alarm`, is unrelated to this
module.)

## Fix

Add `groups="payroll.group_payroll_user"` to the three unprotected fields, matching what
`payslip_count` already does.

Verified at the registry level after the change:

| Field | groups before | groups after |
|---|---|---|
| `hr.version.struct_id` | *(none)* | `payroll.group_payroll_user` |
| `hr.version.schedule_pay` | *(none)* | `payroll.group_payroll_user` |
| `hr.employee.slip_ids` | *(none)* | `payroll.group_payroll_user` |
| `hr.employee.payslip_count` | already set | unchanged |

The module's own test suite still passes (27 tests).

## Note for reviewers

Core's `_test_payroll_fields_are_hidden_to_non_payroll_users` accepts only
`hr.group_hr_manager` or `hr_payroll.group_hr_payroll_user` — the latter being the **Enterprise**
module's group. A module using OCA's own `payroll.group_payroll_user` therefore still trips that
specific assertion even though the underlying access control is now correct.

This PR fixes the actual data exposure. Whether the upstream check should also accept an
equivalent community group is a separate discussion, and I'm happy to follow whatever the
maintainers prefer here (e.g. adding `hr.group_hr_manager` alongside).

---

Assisted-by: Claude Opus 4.8

Disclosed per the [OCA Generative AI / LLM Policy](https://github.com/OCA/.github/blob/master/AI_POLICY.md).
Developed and verified under my direction and review; I take responsibility for the contribution.